### PR TITLE
enable scripts in iframe head

### DIFF
--- a/src/canvas/config/config.js
+++ b/src/canvas/config/config.js
@@ -6,5 +6,8 @@ define(function () {
 		// Coming soon
 		rulers: false,
 
+		// append scripts in head
+		scripts: []
+
 	};
 });

--- a/src/canvas/config/config.js
+++ b/src/canvas/config/config.js
@@ -6,7 +6,10 @@ define(function () {
 		// Coming soon
 		rulers: false,
 
-		// append scripts in head
+		/*
+		 * append scripts in head of iframe before renderBody content
+		 * need to manually maintain the same scripts in cms's render template
+		*/ 
 		scripts: []
 
 	};

--- a/src/canvas/view/CanvasView.js
+++ b/src/canvas/view/CanvasView.js
@@ -31,6 +31,31 @@ function(Backbone, FrameView) {
     },
 
     /**
+     * Insert scripts into head, it will call renderBody after all scripts loaded or failed
+     * @private
+     */
+    renderScripts: function () {
+        var frame = this.frame;
+        var that = this;
+
+        frame.el.onload = function () {
+          var scripts = that.config.scripts,
+              counter = 0;
+
+          scripts.map(function (scriptUrl) {
+            var script = document.createElement('script');
+            script.type = 'text/javascript';
+            script.src = scriptUrl;
+            script.onerror = script.onload = function () {
+              counter++;
+              if (counter == scripts.length) that.renderBody();
+            };
+            frame.el.contentDocument.head.appendChild(script);
+          });
+        };
+    },
+
+    /**
      * Render inside frame's body
      * @private
      */
@@ -198,7 +223,11 @@ function(Backbone, FrameView) {
         this.model.get('frame').set('wrapper', this.wrapper);
         this.$el.append(this.frame.render().el);
         var frame = this.frame;
-        frame.el.onload = this.renderBody;
+        if (this.config.scripts.length === 0) {
+          frame.el.onload = this.renderBody;
+        } else {
+          this.renderScripts(); // will call renderBody later
+        }
       }
       var ppfx = this.ppfx;
       toolsEl = $('<div>', { id: ppfx + 'tools' }).get(0);

--- a/src/canvas/view/CanvasView.js
+++ b/src/canvas/view/CanvasView.js
@@ -39,19 +39,21 @@ function(Backbone, FrameView) {
         var that = this;
 
         frame.el.onload = function () {
-          var scripts = that.config.scripts,
+          var scripts = that.config.scripts.slice(0),  // clone
               counter = 0;
-
-          scripts.map(function (scriptUrl) {
-            var script = document.createElement('script');
-            script.type = 'text/javascript';
-            script.src = scriptUrl;
-            script.onerror = script.onload = function () {
-              counter++;
-              if (counter == scripts.length) that.renderBody();
-            };
-            frame.el.contentDocument.head.appendChild(script);
-          });
+            
+          function appendScript(scripts) {
+            if (scripts.length > 0) {
+              var script = document.createElement('script');
+              script.type = 'text/javascript';
+              script.src = scripts.shift();
+              script.onerror = script.onload = appendScript.bind(null, scripts);
+              frame.el.contentDocument.head.appendChild(script);
+            } else {
+              that.renderBody();
+            }
+          }
+          appendScript(scripts);
         };
     },
 


### PR DESCRIPTION
when i set allowscript option to 1, I tried to add required js library at head using:
```javascript
// ...
editor.render();
var f = editor.Canvas.getFrameEl();
scripts.map((script)=>{
    f.contentDocument.head.appendChild(script);
});
```
however it will fail cause the render body is executed before the code above.
I hope to have a config option to insert the scripts I need.

with the PR, now it can be configured in grapesjs.init 

```javascript
var editor  = grapesjs.init({
    // other options
    canvas: {
        scripts: [
            "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.1/angular.min.js"
        ]
    },
}
```