### PR TITLE
utils module case mismatch

### DIFF
--- a/src/editor/model/Editor.js
+++ b/src/editor/model/Editor.js
@@ -1,5 +1,5 @@
 var deps = [
-require('Utils'),
+require('utils'),
 require('storage_manager'),
 require('device_manager'),
 require('parser'),


### PR DESCRIPTION
Changed utils from capitalize to lowercase to match directory name format to avoid the following error

ERROR in ./src/editor/model/Editor.js
Module not found: Error: Can't resolve 'Utils' in 'grapejs-git/grapesjs/src/editor/model'