### PR TITLE
Updating PropertyFileView file upload modal

### DIFF
--- a/src/style_manager/view/PropertyFileView.js
+++ b/src/style_manager/view/PropertyFileView.js
@@ -120,15 +120,20 @@ module.exports = PropertyView.extend({
    * */
   openAssetManager(e) {
     var that  = this;
-    if(this.modal && this.am){
+    var em = this.em;
+    var editor = em ? em.get('Editor') : '';
+
+    if(editor) {
       this.modal.setTitle('Select image');
       this.modal.setContent(this.am.render());
       this.am.setTarget(null);
-      this.modal.open();
-      this.am.onSelect(model => {
-        that.modal.close();
-        that.spreadUrl(model.get('src'));
-        that.valueChanged(e);
+      editor.runCommand('open-assets', {
+        target: this.model,
+        onSelect(target) {
+          that.modal.close();
+          that.spreadUrl(target.get('src'));
+          that.valueChanged(e);
+        }
       });
     }
   },


### PR DESCRIPTION
@artf This is to resolve #212 an update to the openAssetManager function in PropertyFileView to utilize the open-assets command itself to open the modal.

Reason for this being as I was overriding the built-in image upload function and modal with my own but I noticed when using the same file uploader for a background image it wouldn't even hit my custom overloading uploader as it relies on it running the command function.

Let me know your thoughts on that issue and otherwise if this looks like a good fix to merge in.