### PR TITLE
Use data URL to embed images in documents

### DIFF
--- a/src/asset_manager/view/FileUploader.js
+++ b/src/asset_manager/view/FileUploader.js
@@ -20,7 +20,7 @@ module.exports = Backbone.View.extend({
     this.ppfx = c.pStylePrefix || '';
     this.target = this.options.globalCollection || {};
     this.uploadId = this.pfx + 'uploadFile';
-    this.disabled = c.disabled !== undefined ? c.disabled : !c.upload && !c.embedAsBase64;
+    this.disabled = c.disableUpload !== undefined ? c.disableUpload : !c.upload && !c.embedAsBase64;
     this.events['change #' + this.uploadId]  = 'uploadFile';
     let uploadFile = c.uploadFile;
 

--- a/test/specs/asset_manager/view/FileUploader.js
+++ b/test/specs/asset_manager/view/FileUploader.js
@@ -1,5 +1,6 @@
 var FileUploader = require('asset_manager/view/FileUploader');
 
+
 module.exports = {
   run() {
 
@@ -64,10 +65,20 @@ module.exports = {
 
           it('Could be disabled', () => {
             var view = new FileUploader({ config : {
-              disableUpload: true,
+              disabled: true,
+              upload: 'something'
             } });
             view.render();
             expect(view.$el.find('input[type=file]').prop('disabled')).toEqual(true);
+          });
+          
+          it('Handles embedAsBase64 parameter', () => {
+            var view = new FileUploader({ config : {
+              embedAsBase64: true
+            } });
+            view.render();
+            expect(view.$el.find('input[type=file]').prop('disabled')).toEqual(false);
+            expect(view.uploadFile).toEqual(FileUploader.embedAsBase64);
           });
 
       });

--- a/test/specs/asset_manager/view/FileUploader.js
+++ b/test/specs/asset_manager/view/FileUploader.js
@@ -65,7 +65,7 @@ module.exports = {
 
           it('Could be disabled', () => {
             var view = new FileUploader({ config : {
-              disabled: true,
+              disableUpload: true,
               upload: 'something'
             } });
             view.render();


### PR DESCRIPTION
This PR allows images to be embedded in the document using data URLs.
I spent nearly an hour, but I could not manage to write proper unit tests for this.

Also:
- Adds an undocumented `disabledUpload` options. There was a unit test for it and it worked, but coincidental.
- Do not require for `onUploadResponse` to be a String, can simply be an object.

Also, there's an undocumented `name` attribute that's understood by `AssertView`.