### PR TITLE
npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor/
 coverage/
 node_modules/
 bower_components/
+grapesjs-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test
+index.html
+webpack.config.js
+grapesjs-*.tgz


### PR DESCRIPTION
Some of development resources (eg: tests) are npm ignored. There is no need in production env.