### PR TITLE
Updated ToolbarButtonView to render title attribute if present

### DIFF
--- a/src/dom_components/view/ToolbarButtonView.js
+++ b/src/dom_components/view/ToolbarButtonView.js
@@ -32,6 +32,10 @@ module.exports = Backbone.View.extend({
   render() {
     var config = this.editor.getConfig();
     this.el.className += ' ' + config.stylePrefix + 'toolbar-item';
+    var attr = this.attributes();
+    if (attr.title) {
+      this.el.title = attr.title;
+    }
     return this;
   },
 


### PR DESCRIPTION
If any components specify custom toolbar options, you can include a title attribute. This attribute will now be rendered as an html title, allowing you to give a short description on what the toolbar button actually does.

This change just renders the title attribute (if it exists), it doesn't modify the default toolbars at all.