### PR TITLE
Specify GET Method to Load templates

### DIFF
--- a/src/storage_manager/model/RemoteStorage.js
+++ b/src/storage_manager/model/RemoteStorage.js
@@ -74,15 +74,7 @@ module.exports = require('backbone').Model.extend({
   },
 
   load(keys, clb) {
-    let queryString = '';
-    keys.forEach(function(key, index, keys) {
-      queryString += key;
-      if (index < keys.length - 1) {
-        queryString += ',';
-      }
-    }, this);
-
-    this.request(`${this.get('urlLoad')}?keys=${queryString}`, {method: 'get'}, clb);
+    this.request(this.get('urlLoad'), {method: 'get'}, clb);
   },
 
   /**
@@ -133,18 +125,18 @@ module.exports = require('backbone').Model.extend({
       headers,
     };
 
-    // Body should not be included on GET, HEAD, OPTIONS or DELETE methods
-    if (!bodilessMethods.includes(fetchOptions.method)) {
+    // Body should only be included on POST method
+    if (fetchOptions.method === 'post') {
       fetchOptions.body = body;
     }
 
     this.onStart();
-    this.fetch(url, fetchOptions).then(res => (res.status/200|0) == 1 ?
-      res.text() : res.text().then((text) =>
-        Promise.reject(text)
-      ))
-    .then((text) => this.onResponse(text, clb))
-    .catch(err => this.onError(err));
+    this.fetch(url, fetchOptions)
+      .then(res => (res.status/200|0) == 1
+        ? res.text()
+        : res.text().then((text) => Promise.reject(text)))
+      .then((text) => this.onResponse(text, clb))
+      .catch(err => this.onError(err));
   },
 
 });

--- a/src/storage_manager/model/RemoteStorage.js
+++ b/src/storage_manager/model/RemoteStorage.js
@@ -74,7 +74,7 @@ module.exports = require('backbone').Model.extend({
   },
 
   load(keys, clb) {
-    this.request(this.get('urlLoad'), {body: {keys}}, clb);
+    this.request(this.get('urlLoad'), {body: {keys}, method: 'get'}, clb);
   },
 
   /**

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -5,7 +5,6 @@ window.Promise = window.Promise || Promise;
 export default typeof fetch == 'function' ? fetch.bind() : (url, options) => {
   return new Promise((res, rej) => {
     const req = new XMLHttpRequest();
-    const bodilessMethods = ['get', 'head', 'options', 'delete'];
     req.open(options.method || 'get', url);
     req.withCredentials = options.credentials == 'include';
 
@@ -25,11 +24,7 @@ export default typeof fetch == 'function' ? fetch.bind() : (url, options) => {
       req.upload.onprogress = options.onProgress;
     }
 
-    if (bodilessMethods.includes(options.method)) {
-      req.send();
-    } else {
-      req.send(options.body);
-    }
-
+    // Include body only if present
+    options.body ? req.send(options.body) : req.send();
   });
 }

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -5,6 +5,7 @@ window.Promise = window.Promise || Promise;
 export default typeof fetch == 'function' ? fetch.bind() : (url, options) => {
   return new Promise((res, rej) => {
     const req = new XMLHttpRequest();
+    const bodilessMethods = ['get', 'head', 'options', 'delete'];
     req.open(options.method || 'get', url);
     req.withCredentials = options.credentials == 'include';
 
@@ -24,6 +25,11 @@ export default typeof fetch == 'function' ? fetch.bind() : (url, options) => {
       req.upload.onprogress = options.onProgress;
     }
 
-    req.send(options.body);
+    if (bodilessMethods.includes(options.method)) {
+      req.send();
+    } else {
+      req.send(options.body);
+    }
+
   });
 }

--- a/test/specs/storage_manager/model/Models.js
+++ b/test/specs/storage_manager/model/Models.js
@@ -98,7 +98,7 @@ module.exports = {
         obj.load(['item1', 'item2']);
         const callResult = obj.fetch;
         expect(callResult.called).toEqual(true);
-        expect(callResult.firstCall.args[0]).toEqual(`${endpointLoad}?keys=item1,item2`);
+        expect(callResult.firstCall.args[0]).toEqual(endpointLoad);
       });
 
     });

--- a/test/specs/storage_manager/model/Models.js
+++ b/test/specs/storage_manager/model/Models.js
@@ -98,7 +98,7 @@ module.exports = {
         obj.load(['item1', 'item2']);
         const callResult = obj.fetch;
         expect(callResult.called).toEqual(true);
-        expect(callResult.firstCall.args[0]).toEqual(endpointLoad);
+        expect(callResult.firstCall.args[0]).toEqual(`${endpointLoad}?keys=item1,item2`);
       });
 
     });


### PR DESCRIPTION
RemoteStorage is using `POST` to load templates
Issue: https://github.com/artf/grapesjs/issues/436