### PR TITLE
Add Arguments to Editor.trigger() function

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -539,7 +539,7 @@ module.exports = config => {
      * @return {this}
      */
     trigger(event) {
-      return em.trigger(event);
+      return em.trigger.apply(em, arguments);
     },
 
     /**


### PR DESCRIPTION
Arguments added to a triggered event are not being passed along to backbone's trigger function.