### PR TITLE
Update index.html so that all media files have an absolute path

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
       <section class="am-sect">
         <div class="container-width">
           <div class="am-container">
-            <img class="img-phone" onmousedown="return false" src="./img/phone-app.png"/>
+            <img class="img-phone" onmousedown="return false" src="http://grapesjs.com/img/phone-app.png"/>
             <div class="am-content">
               <div class="am-pre">ASSET MANAGER</div>
               <div class="am-title">Manage your images with Asset Manager</div>
@@ -150,7 +150,7 @@
           <div class="badges">
             <div class="badge">
               <div class="badge-header"></div>
-              <img class="badge-avatar" src="img/team1.jpg">
+              <img class="badge-avatar" src="http://grapesjs.com/img/team1.jpg">
               <div class="badge-body">
                 <div class="badge-name">Adam Smith</div>
                 <div class="badge-role">CEO</div>
@@ -164,7 +164,7 @@
             </div>
             <div class="badge">
               <div class="badge-header"></div>
-              <img class="badge-avatar" src="img/team2.jpg">
+              <img class="badge-avatar" src="http://grapesjs.com/img/team2.jpg">
               <div class="badge-body">
                 <div class="badge-name">John Black</div>
                 <div class="badge-role">Software Engineer</div>
@@ -178,7 +178,7 @@
             </div>
             <div class="badge">
               <div class="badge-header"></div>
-              <img class="badge-avatar" src="img/team3.jpg">
+              <img class="badge-avatar" src="http://grapesjs.com/img/team3.jpg">
               <div class="badge-body">
                 <div class="badge-name">Jessica White</div>
                 <div class="badge-role">Web Designer</div>
@@ -875,9 +875,9 @@
            { type: 'image', src : 'http://placehold.it/350x250/f28c33/fff/image5.jpg', height:350, width:250},
            { type: 'image', src : 'http://placehold.it/350x250/e868a2/fff/image6.jpg', height:350, width:250},
            { type: 'image', src : 'http://placehold.it/350x250/cc4360/fff/image7.jpg', height:350, width:250},
-           { type: 'image', src : './img/work-desk.jpg', date: '2015-02-01',height:1080, width:1728},
-           { type: 'image', src : './img/phone-app.png', date: '2015-02-01',height:650, width:320},
-           { type: 'image', src : './img/bg-gr-v.png', date: '2015-02-01',height:1, width:1728},
+           { type: 'image', src : 'http://grapesjs.com/img/work-desk.jpg', date: '2015-02-01',height:1080, width:1728},
+           { type: 'image', src : 'http://grapesjs.com/img/phone-app.png', date: '2015-02-01',height:650, width:320},
+           { type: 'image', src : 'http://grapesjs.com/img/bg-gr-v.png', date: '2015-02-01',height:1, width:1728},
          ]
       },
 
@@ -946,7 +946,7 @@
             content: '<div class="badges">'+
               '<div class="badge">'+
                 '<div class="badge-header"></div>'+
-                '<img class="badge-avatar" src="img/team1.jpg">'+
+                '<img class="badge-avatar" src="http://grapesjs.com/img/team1.jpg">'+
                 '<div class="badge-body">'+
                   '<div class="badge-name">Adam Smith</div><div class="badge-role">CEO</div><div class="badge-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ipsum dolor sit</div>'+
                 '</div>'+
@@ -954,7 +954,7 @@
               '</div>'+
               '<div class="badge">'+
                 '<div class="badge-header"></div>'+
-                '<img class="badge-avatar" src="img/team2.jpg">'+
+                '<img class="badge-avatar" src="http://grapesjs.com/img/team2.jpg">'+
                 '<div class="badge-body">'+
                   '<div class="badge-name">John Black</div><div class="badge-role">Software Engineer</div><div class="badge-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ipsum dolor sit</div>'+
                 '</div>'+
@@ -962,7 +962,7 @@
               '</div>'+
               '<div class="badge">'+
                 '<div class="badge-header"></div>'+
-                '<img class="badge-avatar" src="img/team3.jpg">'+
+                '<img class="badge-avatar" src="http://grapesjs.com/img/team3.jpg">'+
                 '<div class="badge-body">'+
                   '<div class="badge-name">Jessica White</div><div class="badge-role">Web Designer</div><div class="badge-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ipsum dolor sit</div>'+
                 '</div>'+
@@ -1023,7 +1023,7 @@
             attributes: {class:'fa fa-youtube-play'},
             content: {
               type: 'video',
-              src: 'img/video2.webm',
+              src: 'http://grapesjs.com/img/video2.webm',
               style: {
                 height: '350px',
                 width: '615px',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grapesjs",
   "description": "Free and Open Source Web Builder Framework",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "author": "Artur Arseniev",
   "license": "BSD-3-Clause",
   "homepage": "http://grapesjs.com",


### PR DESCRIPTION
When running the GrapesJS demo locally I noticed that some assets point to invalid paths. e.g. "/img/video2.webm" causing them not to load.

I also noticed that most media was getting loaded from the web, some of them directly from http://grapesjs.com

This pull request is to ensure that those assets that originally had an invalid path, will now be able to load from http://grapesjs.com