### PR TITLE
Add getConfig() function for SelectorManager

### DIFF
--- a/src/selector_manager/index.js
+++ b/src/selector_manager/index.js
@@ -68,6 +68,15 @@ module.exports = config => {
      * @private
      */
     name: 'SelectorManager',
+    
+    /**
+     * Get configuration object
+     * @return {Object}
+     * @private
+     */
+    getConfig() {
+      return c;
+    },
 
     /**
      * Initialize module. Automatically called with a new instance of the editor


### PR DESCRIPTION
SelectorManager is missing a getConfig() function. This adds it in. Only really need it for translation purposes :)