### PR TITLE
Fixing background color for gjs-input-unit

### DIFF
--- a/src/styles/scss/_gjs_inputs.scss
+++ b/src/styles/scss/_gjs_inputs.scss
@@ -58,6 +58,7 @@
 .#{$app-prefix}select option,
 .#{$clm-prefix}select option,
 .#{$sm-prefix}select option,
+.#{$app-prefix}fields option,
 .#{$sm-prefix}unit option {
   background-color: $mainColor;
   color: $fontColor;


### PR DESCRIPTION
Same issue as comboboxes background color for firefox.(https://github.com/artf/grapesjs/issues/456).

After the MR, the selects with class "gjs-input-unit" are still having this issue.

![captura de pantalla 2017-11-07 a la s 16 18 46](https://user-images.githubusercontent.com/12806363/32513040-aa1caad2-c3d7-11e7-8544-c6535840d7ba.png)

Just a quick fix and include the fields option inside the scss