### PR TITLE
Clear cached scroll offset on window scroll

### DIFF
--- a/src/canvas/view/CanvasView.js
+++ b/src/canvas/view/CanvasView.js
@@ -5,6 +5,7 @@ module.exports = Backbone.View.extend({
 
   initialize(o) {
     _.bindAll(this, 'renderBody', 'onFrameScroll', 'clearOff');
+    window.onscroll = this.clearOff
     this.config = o.config || {};
     this.em = this.config.em || {};
     this.ppfx  = this.config.pStylePrefix || '';


### PR DESCRIPTION
Fixes #495 (a bug where the toolbar, highlighter, etc elements’ position 
would be off in editors positioned inside a scrollable window). 