### PR TITLE
Include value-less attributes in component.toHTML()

### DIFF
--- a/src/dom_components/model/Component.js
+++ b/src/dom_components/model/Component.js
@@ -554,7 +554,7 @@ module.exports = Backbone.Model.extend(Styleable).extend({
     for (let attr in attributes) {
       const value = attributes[attr];
 
-      if (!isUndefined(value) && value !== '') {
+      if (!isUndefined(value)) {
           attrs.push(`${attr}="${value}"`);
       }
     }

--- a/test/specs/dom_components/model/Component.js
+++ b/test/specs/dom_components/model/Component.js
@@ -82,6 +82,16 @@ module.exports = {
           expect(obj.toHTML()).toEqual('<article data-test1="value1" data-test2="value2"></article>');
         });
 
+        it('Component toHTML with value-less attribute', () => {
+          obj = new Component({
+            tagName: 'div',
+            attributes: {
+              'data-is-a-test': ''
+            }
+          });
+          expect(obj.toHTML()).toEqual('<div data-is-a-test=""></div>');
+        });
+
         it('Component toHTML with classes', () => {
           obj = new Component({
             tagName: 'article'


### PR DESCRIPTION
This is to fix an issue where boolean attributes (http://w3c.github.io/html/infrastructure.html#sec-boolean-attributes) are being excluded in the HTML returned from editor.getHtml(). For example, starting with code that looks like `<input type="checkbox" checked>`, I would expect the the "checked" attribute to be present when calling editor.getHtml(), but it currently is not. I believe this behavior should apply to custom attributes as well (data-*). 

According to the spec (linked above) it is valid to output boolean attributes with an empty string value, so I think these changes will work for standard boolean attributes (`checked`, `selected`, `disabled`) as well as custom attributes that may or may not have a value (`data-boolean` / `data-test=""`).