### PR TITLE
render text view after disabling editing

### DIFF
--- a/src/dom_components/view/ComponentTextView.js
+++ b/src/dom_components/view/ComponentTextView.js
@@ -82,7 +82,7 @@ module.exports = ComponentView.extend({
         }
 
         // Avoid re-render on reset with silent option
-        model.set('content', '');
+        model.set('content', '').trigger('change:content', model);
         comps.add(content);
         comps.each(model => clean(model));
         comps.trigger('resetNavigator');
@@ -91,7 +91,6 @@ module.exports = ComponentView.extend({
 
     this.rteEnabled = 0;
     this.toggleEvents();
-    this.render();
   },
 
   /**

--- a/src/dom_components/view/ComponentTextView.js
+++ b/src/dom_components/view/ComponentTextView.js
@@ -91,6 +91,7 @@ module.exports = ComponentView.extend({
 
     this.rteEnabled = 0;
     this.toggleEvents();
+    this.render();
   },
 
   /**


### PR DESCRIPTION
this is to fix a bug where text content can appear to be duplicated after adding text content to a component that originally had no content

https://github.com/artf/grapesjs/issues/569