### PR TITLE
Problem event stop:preview not firing solved

### DIFF
--- a/src/commands/view/Preview.js
+++ b/src/commands/view/Preview.js
@@ -28,7 +28,7 @@ module.exports = {
       this.helper.className = pfx + 'off-prv fa fa-eye-slash';
       editorEl.appendChild(this.helper);
       this.helper.onclick = () => {
-        that.stop(editor);
+        editor.stopCommand('preview');
       };
     }
     this.helper.style.display = 'inline-block';


### PR DESCRIPTION
The related event (stop:preview) from src/commands/view/Preview.js were not firing (issue #583). I've found this error in this situation:

I have some elements out of the canvas that need to be hide at preview mode and shown when I exit preview mode. However, the event stop:preview doesn't fire when I exit the preview and turn back to canvas editing. I've made a solution myself that works well, look the commit. Here a screenshot: 
![captura de tela 2017-11-28 as 16 27 05](https://user-images.githubusercontent.com/7770605/33389277-1828fb44-d511-11e7-914d-5b6477432cc2.png)
