### PR TITLE
Escape html

### DIFF
--- a/src/dom_components/model/Component.js
+++ b/src/dom_components/model/Component.js
@@ -630,9 +630,10 @@ module.exports = Backbone.Model.extend(Styleable).extend({
     const tag = model.get('tagName');
     const sTag = model.get('void');
     const attributes = this.getAttrToHTML();
+    const mode_attributes = new Backbone.Model(attributes);
 
     for (let attr in attributes) {
-      const value = attributes[attr];
+      const value = mode_attributes.escape(attr);
 
       if (!isUndefined(value)) {
           attrs.push(`${attr}="${value}"`);

--- a/src/dom_components/model/ComponentTextNode.js
+++ b/src/dom_components/model/ComponentTextNode.js
@@ -8,7 +8,7 @@ module.exports = Component.extend({
   }),
 
   toHTML() {
-    return this.get('content');
+    return this.escape('content');
   },
 
 }, {


### PR DESCRIPTION
When exporting/importing html we need to properly escape/unescape then.

Example:
 <p>A &lt;div&gt; tag can be used for ...</p> ... <input type="text" placeholder="class=&quote;cl&quote;">

