### PR TITLE
Remove duplicated dblclick event listener

### DIFF
--- a/src/dom_components/view/ComponentLinkView.js
+++ b/src/dom_components/view/ComponentLinkView.js
@@ -3,10 +3,6 @@ var ComponentView = require('./ComponentTextView');
 
 module.exports = ComponentView.extend({
 
-  events: {
-    'dblclick': 'enableEditing',
-  },
-
   render(...args) {
     ComponentView.prototype.render.apply(this, args);
 


### PR DESCRIPTION
Hi @artf,

This is just a small change to reduce some duplicated code. The `'dblclick': 'enableEditing'` event is inherited from ComponentTextView, so it seems unnecessary to repeat that code on the ComponentLinkView object. I was experimenting with overriding the dblclick behavior of the ComponentTextView and realized that my changes were not getting applied to links.