### PR TITLE
add "typeof" to fix bug with variable inspection

### DIFF
--- a/src/commands/view/SelectComponent.js
+++ b/src/commands/view/SelectComponent.js
@@ -101,7 +101,7 @@ module.exports = {
       this.updateAttached();
     }
     var model = $(trg).data('model');
-    if (model != 'undefined') {
+    if (typeof model != 'undefined') {
 
       if (!model.get("selectable")) {
         var comp = model && model.parent();


### PR DESCRIPTION
This needs to be `model != undefined` or `typeof model != 'undefined'`, as the `model` variable should never be the string "undefined". The code as currently written throws an error when model is undefined.