### PR TITLE
fix sunset at the left edge of the window

### DIFF
--- a/src/commands/view/SelectComponent.js
+++ b/src/commands/view/SelectComponent.js
@@ -444,7 +444,7 @@ module.exports = {
     });
     var leftPos = pos.left + pos.elementWidth - pos.targetWidth;
     toolbarStyle.top = pos.top + unit;
-    toolbarStyle.left = leftPos + unit;
+    toolbarStyle.left = (leftPos < 0 ? 0 : leftPos) + unit;
     toolbarStyle.display = origDisp;
   },
 


### PR DESCRIPTION
If the element is small and is close to the left edge of the screen, the toolbar goes over the edge and is not visible.