### PR TITLE
Fix for issue #796

### DIFF
--- a/src/utils/ColorPicker.js
+++ b/src/utils/ColorPicker.js
@@ -1203,7 +1203,7 @@
           maxWidth = $(element).width();
           offset = $(element).offset();
 
-          $(doc).bind(duringDragEvents);
+          $(element).bind(duringDragEvents);
           $(doc.body).addClass('sp-dragging');
 
           move(e);
@@ -1215,7 +1215,7 @@
 
     function stop() {
       if (dragging) {
-        $(doc).unbind(duringDragEvents);
+        $(element).unbind(duringDragEvents);
         $(doc.body).removeClass('sp-dragging');
 
         // Wait a tick before notifying observers to allow the click event


### PR DESCRIPTION
Proposed fix for https://github.com/artf/grapesjs/issues/796 .  I've bound drag events to the picker element rather than the document, and unbound from the same.
