### PR TITLE
Hide very large labels on blocks

### DIFF
--- a/src/block_manager/view/BlockView.js
+++ b/src/block_manager/view/BlockView.js
@@ -70,7 +70,7 @@ module.exports = Backbone.View.extend({
     const className = `${pfx}block`;
     const label = this.model.get('label');
     el.className += ` ${className} ${pfx}one-bg ${pfx}four-color-h`;
-    el.innerHTML = `<div class="${className}-label">${label}</div>`;
+    el.innerHTML = `<div title="${label}" class="${className}-label">${label}</div>`;
     hasDnd(this.em) && el.setAttribute('draggable', true);
     return this;
   }

--- a/src/styles/scss/_gjs_blocks.scss
+++ b/src/styles/scss/_gjs_blocks.scss
@@ -31,7 +31,7 @@
   width: 45%;
   padding: 1em;
   box-sizing: border-box;
-  height: 90px;
+  height: 103px;
   cursor: all-scroll;
   font-size: 11px;
   font-weight: lighter;
@@ -71,6 +71,8 @@
   font-size: 0.65rem;
   font-weight: normal;
   font-family: Helvetica, sans-serif;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .#{$app-prefix}block.#{$app-prefix}bdrag {


### PR DESCRIPTION
 * Added css to hide very large labels. 
* Added title to label class, thus it shows the text on a tooltip.

Before:

![image](https://user-images.githubusercontent.com/22417566/36226165-df62b3c2-11ab-11e8-8083-02b09a522a2c.png)

Now:

![label tooltip](https://user-images.githubusercontent.com/22417566/36226300-2f77ef4e-11ac-11e8-9e43-f499933a79da.png)
