### PR TITLE
prevent grapes.js from being injected twice during development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = env => {
     const index = 'index.html';
     const indexDev = `_${index}`;
     const template = fs.existsSync(indexDev) ? indexDev : index;
-    plugins.push(new HtmlWebpackPlugin({ template }));
+    plugins.push(new HtmlWebpackPlugin({ template, inject: false }));
   }
 
   plugins.push(new webpack.ProvidePlugin({


### PR DESCRIPTION
Very minor fix on development where previously the javascript bundle was injected twice:

<img width="622" alt="screen shot 2018-03-06 at 09 44 54" src="https://user-images.githubusercontent.com/331833/37022457-5b62977c-2123-11e8-8380-2a1be31dbc9c.png">

After this PR this is fixed:

<img width="662" alt="screen shot 2018-03-06 at 09 45 18" src="https://user-images.githubusercontent.com/331833/37022479-6361ea9a-2123-11e8-80a2-bf66f1b668f7.png">

Does not affect tests.