### PR TITLE
New feature: expose `baseCss` (non-breaking & with tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,15 @@ You could also grab the content directly from the element with `fromElement` pro
 
 For more practical example I suggest to look up the code inside this demo: http://grapesjs.com/demo.html
 
+By default Grapes injects base CSS into the canvas. For example, it sets body margin to 0 and sets a default background color of white. This CSS is desired in most cases. However, if you wish to disable or define your own base CSS, you can do so with the `baseCss` config parameter. This is useful if for example your template is not based off a document with 0 as body margin:
 
-
+```javascript
+var editor = grapesjs.init({
+    container : '#gjs',
+    fromElement: true,
+    baseCss: 'html, body { background-color: #ffffff; }'
+});
+```
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -123,16 +123,6 @@ You could also grab the content directly from the element with `fromElement` pro
 
 For more practical example I suggest to look up the code inside this demo: http://grapesjs.com/demo.html
 
-By default Grapes injects base CSS into the canvas. For example, it sets body margin to 0 and sets a default background color of white. This CSS is desired in most cases. However, if you wish to disable or define your own base CSS, you can do so with the `baseCss` config parameter. This is useful if for example your template is not based off a document with 0 as body margin:
-
-```javascript
-var editor = grapesjs.init({
-    container : '#gjs',
-    fromElement: true,
-    baseCss: 'html, body { background-color: #ffffff; }'
-});
-```
-
 
 ## Development
 

--- a/src/canvas/view/CanvasView.js
+++ b/src/canvas/view/CanvasView.js
@@ -97,23 +97,7 @@ module.exports = Backbone.View.extend({
 
       const colorWarn = '#ffca6f';
 
-      let baseCss = `
-        * {
-          box-sizing: border-box;
-        }
-        html, body, #wrapper {
-          min-height: 100%;
-        }
-        body {
-          margin: 0;
-          height: 100%;
-          background-color: #fff
-        }
-        #wrapper {
-          overflow: auto;
-          overflow-x: hidden;
-        }
-      `;
+      // I need all this styles to make the editor work properly
       // Remove `html { height: 100%;}` from the baseCss as it gives jumpings
       // effects (on ENTER) with RTE like CKEditor (maybe some bug there?!?)
       // With `body {height: auto;}` jumps in CKEditor are removed but in
@@ -121,10 +105,8 @@ module.exports = Backbone.View.extend({
       // `body {height: 100%;}`.
       // For the moment I give the priority to Firefox as it might be
       // CKEditor's issue
-
-      // I need all this styles to make the editor work properly
       var frameCss = `
-        ${baseCss}
+        ${em.config.baseCss || ''}
 
         .${ppfx}dashed *[data-highlightable] {
           outline: 1px dashed rgba(170,170,170,0.7);
@@ -169,18 +151,6 @@ module.exports = Backbone.View.extend({
         .${ppfx}grabbing {
           cursor: grabbing;
           cursor: -webkit-grabbing;
-        }
-
-        * ::-webkit-scrollbar-track {
-          background: rgba(0, 0, 0, 0.1)
-        }
-
-        * ::-webkit-scrollbar-thumb {
-          background: rgba(255, 255, 255, 0.2)
-        }
-
-        * ::-webkit-scrollbar {
-          width: 10px
         }
 
         ${conf.canvasCss || ''}

--- a/src/editor/config/config.js
+++ b/src/editor/config/config.js
@@ -30,6 +30,40 @@ module.exports = {
   // Width for the editor container
   width: '100%',
 
+  // By default Grapes injects base CSS into the canvas. For example, it sets body margin to 0
+  // and sets a default background color of white. This CSS is desired in most cases.
+  // use this property if you wish to overwrite the base CSS to your own CSS. This is most
+  // useful if for example your template is not based off a document with 0 as body margin.
+  baseCss: `
+    * {
+      box-sizing: border-box;
+    }
+    html, body, #wrapper {
+      min-height: 100%;
+    }
+    body {
+      margin: 0;
+      height: 100%;
+      background-color: #fff
+    }
+    #wrapper {
+      overflow: auto;
+      overflow-x: hidden;
+    }
+    
+    * ::-webkit-scrollbar-track {
+      background: rgba(0, 0, 0, 0.1)
+    }
+
+    * ::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.2)
+    }
+
+    * ::-webkit-scrollbar {
+      width: 10px
+    }
+  `,
+
   // CSS that could only be seen (for instance, inside the code viewer)
   protectedCss: '* { box-sizing: border-box; } body {margin: 0;}',
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,7 +3,10 @@ import expect from 'expect';
 import sinon from 'sinon';
 import { JSDOM } from 'jsdom';
 
-const dom = new JSDOM('<!doctype html><html><body></body></html>');
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  resources: 'usable',
+  pretendToBeVisual: true
+});
 const window = dom.window;
 
 // Fix for the require of jquery
@@ -28,6 +31,7 @@ var localStorage = {
   }
 };
 
+global.dom = dom;
 global.window = window;
 global.document = window.document;
 global.FormData = window.FormData;

--- a/test/helper.js
+++ b/test/helper.js
@@ -4,8 +4,7 @@ import sinon from 'sinon';
 import { JSDOM } from 'jsdom';
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>', {
-  resources: 'usable',
-  pretendToBeVisual: true
+  resources: 'usable'
 });
 const window = dom.window;
 
@@ -31,7 +30,6 @@ var localStorage = {
   }
 };
 
-global.dom = dom;
 global.window = window;
 global.document = window.document;
 global.FormData = window.FormData;

--- a/test/specs/grapesjs/index.js
+++ b/test/specs/grapesjs/index.js
@@ -79,19 +79,30 @@ describe('GrapesJS', () => {
       expect(editor.getStyle().length).toEqual(0);
     });
 
-    // FIXME: remove .only
-    it.only('Editor canvas baseCSS can be overwritten', done => {
+    it('Editor canvas baseCSS can be overwritten', () => {
       config.components = htmlString;
-      config.baseCss = '#wrapper { background-color: #fff; }';
+      config.baseCss = '#wrapper { background-color: #eee; }';
+      config.protectedCss = '';
+
       var editor = obj.init(config);
 
-      const frame = editor.Canvas.getFrameEl();
-      console.log(frame);
-      frame.onload = () => {
-        // FIXME: this never fires
-        console.log(frame.contentDocument.outerHTML);
-        done();
-      };
+      expect(window.frames[0].document.documentElement.outerHTML).toInclude(
+        config.baseCss
+      );
+      expect(window.frames[0].document.documentElement.outerHTML)
+        .toNotInclude(`body {
+      margin: 0;`);
+    });
+
+    it('Editor canvas baseCSS defaults to sensible values if not defined', () => {
+      config.components = htmlString;
+      config.protectedCss = '';
+
+      var editor = obj.init(config);
+
+      expect(window.frames[0].document.documentElement.outerHTML)
+        .toInclude(`body {
+      margin: 0;`);
     });
 
     it('Init editor with html', () => {

--- a/test/specs/grapesjs/index.js
+++ b/test/specs/grapesjs/index.js
@@ -69,7 +69,10 @@ describe('GrapesJS', () => {
     });
 
     it('New editor is empty', () => {
-      var editor = obj.init(config);
+      var editor = obj.init({
+        ...config,
+        baseCss: '#wrapper { background-color: #fff; }'
+      });
       var html = editor.getHtml();
       //var css = editor.getCss();
       var protCss = editor.getConfig().protectedCss;
@@ -77,6 +80,21 @@ describe('GrapesJS', () => {
       //expect((css ? css : '')).toEqual(protCss);
       expect(editor.getComponents().length).toEqual(0);
       expect(editor.getStyle().length).toEqual(0);
+    });
+
+    // FIXME: remove .only
+    it.only('Editor canvas baseCSS can be overwritten', done => {
+      config.components = htmlString;
+      config.baseCss = '#wrapper { background-color: #fff; }';
+      var editor = obj.init(config);
+
+      const frame = editor.Canvas.getFrameEl();
+      console.log(frame);
+      frame.onload = () => {
+        // FIXME: this never fires
+        console.log(frame.contentDocument.outerHTML);
+        done();
+      };
     });
 
     it('Init editor with html', () => {

--- a/test/specs/grapesjs/index.js
+++ b/test/specs/grapesjs/index.js
@@ -69,10 +69,7 @@ describe('GrapesJS', () => {
     });
 
     it('New editor is empty', () => {
-      var editor = obj.init({
-        ...config,
-        baseCss: '#wrapper { background-color: #fff; }'
-      });
+      var editor = obj.init(config);
       var html = editor.getHtml();
       //var css = editor.getCss();
       var protCss = editor.getConfig().protectedCss;


### PR DESCRIPTION
Hey @artf,

I'd like to submit a PR to expose the `baseCss` property of the canvas.

Reason this is necessary is because the `baseCss` is slightly opinionated, e.g. it defines body margin to be 0. In many cases this is not desirable. This is a non-breaking change, as the default behavior is the same.

I've included tests that verify the default (non-breaking) and overwriting behavior.

Do you have any concerns before merging or are you happy with this? I'm happy to further improve it if necessary.

Much appreciated <3