### PR TITLE
Remove unnecessary duplicated property in block_manager config.js

### DIFF
--- a/src/block_manager/config/config.js
+++ b/src/block_manager/config/config.js
@@ -3,7 +3,5 @@ module.exports = {
   // With the empty value, nothing will be rendered
   appendTo: '',
 
-  blocks: [],
-
-  appendTo: ''
+  blocks: []
 };


### PR DESCRIPTION
Hey,
as you can see the configuration already has the property `appendTo` so I removed the duplicated property.