### PR TITLE
Ignore yarn files so contributors can use yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .project
 .idea
 npm-debug.log*
+yarn-error.log
+yarn.lock
 style/.sass-cache/
 
 img/


### PR DESCRIPTION
Basically, with these files ignored, I can use yarn and not worry about accidentally including these in future Pull Requests. Thoughts?

No related issue. I did check the guideline on creating an issue, but this is such a small thing that it seemed unnecessary - let me know otherwise.