### PR TITLE
Allow multiple at-rules, fixes #1032

### DIFF
--- a/src/css_composer/index.js
+++ b/src/css_composer/index.js
@@ -182,8 +182,13 @@ module.exports = () => {
       var w = width || '';
       var opt = { ...opts };
       var rule = this.get(selectors, s, w, opt);
-      if (rule) return rule;
-      else {
+
+      // do not create rules that were found before
+      // unless this is an at-rule, for which multiple declarations
+      // make sense (e.g. multiple `@font-type`s)
+      if (rule && rule.config && !rule.config.atRuleType) {
+        return rule;
+      } else {
         opt.state = s;
         opt.mediaText = w;
         opt.selectors = '';

--- a/test/specs/grapesjs/index.js
+++ b/test/specs/grapesjs/index.js
@@ -157,6 +157,26 @@ describe('GrapesJS', () => {
       expect(editor.getStyle().length).toEqual(2);
     });
 
+    it('Init editor from element with multiple font-face at-rules', () => {
+      config.fromElement = 1;
+      config.storageManager = { type: 0 };
+      fixture.innerHTML =
+        `
+      <style>
+        @font-face {
+          font-family: 'Glyphicons Halflings';
+          src: url(https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/fonts/glyphicons-halflings-regular.woff2) format('woff2');
+        @font-face {
+          font-family: 'Droid Sans';
+          src: url(https://fonts.gstatic.com/s/droidsans/v8/SlGVmQWMvZQIdix7AFxXkHNSbRYXags.woff2) format('woff2');
+        }
+      </style>` + htmlString;
+      const editor = obj.init(config);
+      const css = editor.getCss();
+      const styles = editor.getStyle();
+      expect(styles.length).toEqual(2);
+    });
+
     it('Set components as HTML', () => {
       var editor = obj.init(config);
       editor.setComponents(htmlString);

--- a/test/specs/grapesjs/index.js
+++ b/test/specs/grapesjs/index.js
@@ -166,6 +166,7 @@ describe('GrapesJS', () => {
         @font-face {
           font-family: 'Glyphicons Halflings';
           src: url(https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/fonts/glyphicons-halflings-regular.woff2) format('woff2');
+        }
         @font-face {
           font-family: 'Droid Sans';
           src: url(https://fonts.gstatic.com/s/droidsans/v8/SlGVmQWMvZQIdix7AFxXkHNSbRYXags.woff2) format('woff2');

--- a/test/specs/parser/model/ParserCss.js
+++ b/test/specs/parser/model/ParserCss.js
@@ -277,6 +277,39 @@ module.exports = {
         expect(obj.parse(str)).toEqual(result);
       });
 
+      it('Parses multiple font-face at-rules', () => {
+        const str = `
+          @font-face {
+            font-family: "Open Sans";
+          }
+          @font-face {
+            font-family: 'Glyphicons Halflings';
+            src:url(https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/fonts/glyphicons-halflings-regular.eot)
+          }`;
+        const result = [
+          {
+            selectors: [],
+            selectorsAdd: '',
+            style: { 'font-family': '"Open Sans"' },
+            singleAtRule: 1,
+            atRuleType: 'font-face'
+          },
+          {
+            selectors: [],
+            selectorsAdd: '',
+            style: {
+              'font-family': "'Glyphicons Halflings'",
+              src:
+                'url(https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/fonts/glyphicons-halflings-regular.eot)'
+            },
+            singleAtRule: 1,
+            atRuleType: 'font-face'
+          }
+        ];
+        const parsed = obj.parse(str);
+        expect(parsed).toEqual(result);
+      });
+
       it('Parse ID rule', () => {
         var str = `#test { color: red }`;
         var result = {

--- a/test/specs/parser/model/ParserHtml.js
+++ b/test/specs/parser/model/ParserHtml.js
@@ -372,7 +372,7 @@ module.exports = {
         expect(res.css).toEqual(resCss);
       });
 
-      it.only('Respect multiple font-faces contained in styles in html', () => {
+      it('Respect multiple font-faces contained in styles in html', () => {
         const str = `
           <style>
           @font-face {

--- a/test/specs/parser/model/ParserHtml.js
+++ b/test/specs/parser/model/ParserHtml.js
@@ -372,6 +372,50 @@ module.exports = {
         expect(res.css).toEqual(resCss);
       });
 
+      it.only('Respect multiple font-faces contained in styles in html', () => {
+        const str = `
+          <style>
+          @font-face {
+            font-family: "Open Sans";
+            src:url(https://fonts.gstatic.com/s/droidsans/v8/SlGVmQWMvZQIdix7AFxXkHNSbRYXags.woff2)
+          }
+          @font-face {
+            font-family: 'Glyphicons Halflings';
+            src:url(https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/fonts/glyphicons-halflings-regular.eot)
+          }
+          </style>
+          <div>a div</div>
+        `;
+
+        const expected = [
+          {
+            selectors: [],
+            selectorsAdd: '',
+            style: {
+              'font-family': '"Open Sans"',
+              src:
+                'url(https://fonts.gstatic.com/s/droidsans/v8/SlGVmQWMvZQIdix7AFxXkHNSbRYXags.woff2)'
+            },
+            singleAtRule: 1,
+            atRuleType: 'font-face'
+          },
+          {
+            selectors: [],
+            selectorsAdd: '',
+            style: {
+              'font-family': "'Glyphicons Halflings'",
+              src:
+                'url(https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/fonts/glyphicons-halflings-regular.eot)'
+            },
+            singleAtRule: 1,
+            atRuleType: 'font-face'
+          }
+        ];
+
+        const res = obj.parse(str, new ParserCss());
+        expect(res.css).toEqual(expected);
+      });
+
       it('Parse nested div with text and spaces', () => {
         var str = '<div> <p>TestText</p> </div>';
         var result = {


### PR DESCRIPTION
The CSS parser is trying to be smart by not adding CSS rules twice if they share the same selector. However, this does not work for at-rules, because these can be defined multiple times with the same selector, yet have different impact (e.g. multiple `@font-face` declarations).

- Fixes #1032 
- Added 3 more test cases
- All tests pass