### PR TITLE
WIP: Dump unused styles

### DIFF
--- a/src/code_manager/model/CssGenerator.js
+++ b/src/code_manager/model/CssGenerator.js
@@ -59,7 +59,7 @@ module.exports = require('backbone').Model.extend({
           return;
         }
 
-        code += this.buildFromRule(rule, dump);
+        code += this.buildFromRule(rule, dump, opts);
       });
 
       // Get at-rules
@@ -84,7 +84,7 @@ module.exports = require('backbone').Model.extend({
    * @param {Model} rule
    * @return {string} CSS string
    */
-  buildFromRule(rule, dump) {
+  buildFromRule(rule, dump, opts = {}) {
     let result = '';
     const selectorStrNoAdd = rule.selectorsToString({ skipAdd: 1 });
     const selectorsAdd = rule.get('selectorsAdd');
@@ -94,7 +94,11 @@ module.exports = require('backbone').Model.extend({
     // This will not render a rule if there is no its component
     rule.get('selectors').each(selector => {
       const name = selector.getFullName();
-      if (this.compCls.indexOf(name) >= 0 || this.ids.indexOf(name) >= 0) {
+      if (
+        this.compCls.indexOf(name) >= 0 ||
+        this.ids.indexOf(name) >= 0 ||
+        opts.dumpUnusedSelectors
+      ) {
         found = 1;
       }
     });

--- a/src/commands/view/ExportTemplate.js
+++ b/src/commands/view/ExportTemplate.js
@@ -22,7 +22,7 @@ module.exports = {
     modal.setContent(this.$editors);
     modal.open();
     this.htmlEditor.setContent(editor.getHtml());
-    this.cssEditor.setContent(editor.getCss());
+    this.cssEditor.setContent(editor.getCss({ dumpUnusedSelectors: 1 }));
   },
 
   stop(editor) {

--- a/src/editor/model/Editor.js
+++ b/src/editor/model/Editor.js
@@ -305,15 +305,16 @@ module.exports = Backbone.Model.extend({
     const config = this.config;
     const wrappesIsBody = config.wrappesIsBody;
     const avoidProt = opts.avoidProtected;
+    const dumpUnusedSelectors = opts.dumpUnusedSelectors || false;
     const cssc = this.get('CssComposer');
     const wrp = this.get('DomComponents').getComponent();
     const protCss = !avoidProt ? config.protectedCss : '';
-
     return (
       protCss +
       this.get('CodeManager').getCode(wrp, 'css', {
         cssc,
-        wrappesIsBody
+        wrappesIsBody,
+        dumpUnusedSelectors
       })
     );
   },


### PR DESCRIPTION
Hi @artf ,

  As you may know, after import a html within grapesjs I need to dump those styles even if they aren't being used by any component within the canvas.

  I have made some basic changes to be able to dump those unused classes when I call `editor.getCss()` .

  This PR is still WIP because I would love to hear some feedback from you, to see what you think about it and if it has chances to be merged back on dev branch. 

   If you agree on this, I will improve the tests and create a parameter to be able to configure that when calling `grapesjs.init` also.

  Let me know what do you think!

  This is a PR #1053 related to that
