### PR TITLE
Add option to specify a rootNode for layerManager

### DIFF
--- a/src/navigator/config/config.js
+++ b/src/navigator/config/config.js
@@ -14,6 +14,9 @@ module.exports = {
   // Hide textnodes
   hideTextnode: 1,
 
+  // Optionally specify the id of the node to show as root
+  rootNodeId: null,
+
   // Indicates if the wrapper is visible in layers
   showWrapper: 1
 };

--- a/src/navigator/index.js
+++ b/src/navigator/index.js
@@ -23,14 +23,35 @@ module.exports = () => {
     onLoad() {
       const collection = em.get('DomComponents').getComponents();
       const parent = collection.parent;
+      let rootNode;
+
+      function recursiveFind(object) {
+        if (
+          object.attributes &&
+          object.attributes.attributes.id === config.rootNodeId
+        ) {
+          return object;
+        } else if (object.get('components')) {
+          return object
+            .get('components')
+            .models.map(recursiveFind)
+            .filter(function(n) {
+              return n != null;
+            })[0];
+        }
+      }
+
       const options = {
         level: 0,
         config,
         opened: config.opened || {}
       };
 
-      // Show wrapper if requested
-      if (config.showWrapper && parent) {
+      if (config.rootNodeId) rootNode = recursiveFind(parent);
+      if (config.rootNodeId && rootNode) {
+        View = ItemView;
+        options.model = rootNode;
+      } else if (config.showWrapper && parent) {
         View = ItemView;
         options.model = parent;
       } else {


### PR DESCRIPTION
Fixes #1096 

There's probably room for improvement of this PR on the `recursiveFind` method. I've implemented this as I didn't find the proper way to do it in Backbone, but I assume there must be a better way? Any pointers on this are welcome.

How to use this:

```html
<div id="gjs">
  <div class="menu-container">
    <div class="side-menu"></div>
    <div id="my-root"><!-- Users will append content here --></div>
  </div>
</div>
```

```javascript
const editor = grapesjs.init({
  container: '#gjs',
  layerManager: { rootNodeId: 'my-root' },
  // ...
})
```

