### PR TITLE
Fix onHover

### DIFF
--- a/src/commands/view/SelectComponent.js
+++ b/src/commands/view/SelectComponent.js
@@ -95,7 +95,7 @@ module.exports = {
 
     if (model && !model.get('hoverable')) {
       let parent = model && model.parent();
-      while (parent && !parent.get('hoverable')) parent = comp.parent();
+      while (parent && !parent.get('hoverable')) parent = parent.parent();
       model = parent;
     }
 


### PR DESCRIPTION
There's a reference to a `comp` variable which doesn't exist. I believe this PR fixes it.

Solves https://github.com/artf/grapesjs/issues/1275