### PR TITLE
Allow plugins to be defined as functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,8 @@ module.exports = (() => {
 
         if (plugin) {
           plugin(editor, config.pluginsOpts[pluginId] || {});
+        } else if (typeof pluginId === 'function') {
+          pluginId(editor, config.pluginsOpts[pluginId] || {});
         } else {
           console.warn(`Plugin ${pluginId} not found`);
         }


### PR DESCRIPTION
As a developer that is using a lot of custom GrapesJS plugins, I would like to import plugins and use them directly without having to define them in the global plugin registry.

This allows my code to be more modular without having to worry about another plugin using the same string namespace that my plugin is trying to use.

Benefits:
- Avoids the possibility of namespace conflicts
- Lowers the bar for people to develop their first plugin
- Allows for vanilla javascript plugin composition and higher order plugins
- Plugins don't need to import and/or bundle Grapes [e.g. nicer boilerplate](https://github.com/artf/grapesjs-plugin-boilerplate/blob/master/src/index.js#L5)


## Using imports
```
  import grapesPluginFn from "./awesomePlugin";

  const editor = grapesjs.init({
      container : '#gjs',
      plugins: ['my-plugin-name', grapesPluginFn ]
  });
```

## Using local plugins
```
  function customizeMyEditor(editor,options){
     editor.BlockManager.add('test-block', {
        ...
     });
  }

  const editor = grapesjs.init({
      container : '#gjs',
      plugins: ['my-plugin-name', customizeMyEditor]
  });
```

## Lambda plugins
```
  const editor = grapesjs.init({
      container : '#gjs',
      plugins: ['my-plugin-name', (editor) => console.log("Pimping the editor before it renders", editor)]
  });
```