### PR TITLE
Prevent error when there's no activeElement during undo/redo

### DIFF
--- a/src/canvas/index.js
+++ b/src/canvas/index.js
@@ -363,7 +363,11 @@ module.exports = () => {
      * @return {Boolean}
      */
     isInputFocused() {
-      return this.getFrameEl().contentDocument.activeElement.tagName !== 'BODY';
+      let contentDocument = this.getFrameEl().contentDocument;
+      return (
+        contentDocument.activeElement &&
+        contentDocument.activeElement.tagName !== 'BODY'
+      );
     },
 
     /**


### PR DESCRIPTION
Our errors logs picked up a lot of "Cannot read property 'activeElement' of null" errors so I put in a check.

I did spot the comment above the function:
```
    /**
     * Detects if some input is focused (input elements, text components, etc.)
     * Used internally, for example, to avoid undo/redo in text editing mode
     * @return {Boolean}
     */
```
The function only seems to return true is tag isn't BODY which doesn't match the comments. Is this correct?