### PR TITLE
Initial execution of PropertyCheckbox.

### DIFF
--- a/src/style_manager/model/Properties.js
+++ b/src/style_manager/model/Properties.js
@@ -66,6 +66,16 @@ module.exports = require('backbone')
         }
       },
       {
+        id: 'checkbox',
+        model: require('./PropertyCheckbox'),
+        view: require('./../view/PropertyCheckboxView'),
+        isType(value) {
+          if (value && value.type == 'checkbox') {
+            return value;
+          }
+        }
+      },
+      {
         id: 'slider',
         model: require('./PropertySlider'),
         view: require('./../view/PropertySliderView'),

--- a/src/style_manager/model/PropertyCheckbox.js
+++ b/src/style_manager/model/PropertyCheckbox.js
@@ -1,0 +1,3 @@
+const Property = require('./Property');
+
+module.exports = Property.extend({});

--- a/src/style_manager/view/PropertyCheckboxView.js
+++ b/src/style_manager/view/PropertyCheckboxView.js
@@ -1,0 +1,45 @@
+import Backbone from 'backbone';
+const PropertyView = require('./PropertyView');
+const $ = Backbone.$;
+
+module.exports = PropertyView.extend({
+  templateInput(model) {
+    const ppfx = this.ppfx;
+    const cls = model.get('className');
+    const id = model.get('property');
+    const value = model.get('value');
+
+    return `
+      <div class="${ppfx}field ${ppfx}field-checkbox">
+        <input id="${id}" type="checkbox" value="${value}" />
+        <label class="${cls}" for="${id}"></label>
+      </div>
+    `;
+  },
+
+  templateLabel(model) {
+    const hideName = model.get('hideLabel');
+    if (!hideName) return '<b data-clear-style></b>';
+
+    return this.constructor.__super__.templateLabel(model);
+  },
+
+  init() {
+    const model = this.model;
+    this.listenTo(model, 'change:unit', this.modelValueChanged);
+    this.listenTo(model, 'el:change', this.elementUpdated);
+  },
+
+  setValue(value) {
+    const el = this.el.querySelector('input[type=checkbox]');
+    el.checked = value === this.model.get('on');
+  },
+
+  getInputValue(e) {
+    const isOn = this.el.querySelector('input[type=checkbox]').checked;
+
+    if (isOn) return this.model.get('on');
+
+    return this.model.get('off');
+  }
+});

--- a/src/styles/scss/_gjs_inputs.scss
+++ b/src/styles/scss/_gjs_inputs.scss
@@ -235,6 +235,35 @@
   padding: $inputPadding;
 }
 
+
+.#{$app-prefix}field-checkbox {
+  display: block;
+  flex: 1 1 auto;
+  text-align: center;
+  background: transparent;
+
+  label {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 3px;
+    cursor: pointer;
+    background-color: $mainDkColor;
+
+    &:hover {
+      background-color: $mainDkColor;
+    }
+  }
+
+  input:checked + label {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  input {
+    display: none;
+  }
+}
+
 .#{$app-prefix}field-units {
   position: absolute;
   margin: auto;


### PR DESCRIPTION
This is a very initial execution of PropertyCheckbox which allows toggles for Style Manager.

My usecase is to have something like this:

![screenshot_20180818_044619](https://user-images.githubusercontent.com/120439/44298949-a7982300-a2a1-11e8-9249-b3b1c738e8ba.png)

in the style manager

A few notes:

1. The checkboxes look like toggles. Just like PropertyRadio.
2. There is an option to hide the name and clear button of each property.
3. Is the HTML/CSS structure OK?
4. Each property defines an `on` and and `off` value. When toggled on, it sets the property to `on` value and vice versa. Does that make sense?