### PR TITLE
S3 compatible asset manager

### DIFF
--- a/docs/modules/Assets.md
+++ b/docs/modules/Assets.md
@@ -66,6 +66,10 @@ Below the list of currently available options
   // The credentials setting for the upload request, eg. 'include', 'omit'
   credentials: 'include',
 
+  // Allow uploading multiple files per request.
+  // If disabled filename will not have '[]' appended
+  multiUpload: true,
+
   // If true, tries to add automatically uploaded assets.
   // To make it work the server should respond with a JSON containing assets
   // in a data key, eg:

--- a/docs/modules/Assets.md
+++ b/docs/modules/Assets.md
@@ -63,6 +63,9 @@ Below the list of currently available options
   // Custom parameters to pass with the upload request, eg. csrf token
   params: {},
 
+  // The credentials setting for the upload request, eg. 'include', 'omit'
+  credentials: 'include',
+
   // If true, tries to add automatically uploaded assets.
   // To make it work the server should respond with a JSON containing assets
   // in a data key, eg:

--- a/src/asset_manager/config/config.js
+++ b/src/asset_manager/config/config.js
@@ -29,6 +29,9 @@ module.exports = {
   // Custom parameters to pass with the upload request, eg. csrf token
   params: {},
 
+  // The credentials setting for the upload request, eg. 'include', 'omit'
+  credentials: 'include',
+
   // If true, tries to add automatically uploaded assets.
   // To make it work the server should respond with a JSON containing assets
   // in a data key, eg:

--- a/src/asset_manager/config/config.js
+++ b/src/asset_manager/config/config.js
@@ -32,6 +32,10 @@ module.exports = {
   // The credentials setting for the upload request, eg. 'include', 'omit'
   credentials: 'include',
 
+  // Allow uploading multiple files per request.
+  // If disabled filename will not have '[]' appended
+  multiUpload: true,
+
   // If true, tries to add automatically uploaded assets.
   // To make it work the server should respond with a JSON containing assets
   // in a data key, eg:

--- a/src/asset_manager/view/FileUploader.js
+++ b/src/asset_manager/view/FileUploader.js
@@ -7,7 +7,7 @@ module.exports = Backbone.View.extend(
     template: _.template(`
   <form>
     <div id="<%= pfx %>title"><%= title %></div>
-    <input type="file" id="<%= uploadId %>" name="file" accept="*/*" <%= disabled ? 'disabled' : '' %> multiple/>
+    <input type="file" id="<%= uploadId %>" name="file" accept="*/*" <%= disabled ? 'disabled' : '' %> <%= multiUpload ? 'multiple' : '' %>/>
     <div style="clear:both;"></div>
   </form>
   `),
@@ -26,6 +26,7 @@ module.exports = Backbone.View.extend(
         c.disableUpload !== undefined
           ? c.disableUpload
           : !c.upload && !c.embedAsBase64;
+      this.multiUpload = c.multiUpload !== undefined ? c.multiUpload : true;
       this.events['change #' + this.uploadId] = 'uploadFile';
       let uploadFile = c.uploadFile;
 
@@ -78,7 +79,13 @@ module.exports = Backbone.View.extend(
       const em = this.config.em;
       const config = this.config;
       const target = this.target;
-      const json = typeof text === 'string' ? JSON.parse(text) : text;
+      let json;
+      try {
+        json = typeof text === 'string' ? JSON.parse(text) : text;
+      } catch (e) {
+        json = text;
+      }
+
       em && em.trigger('asset:upload:response', json);
 
       if (config.autoAdd && target) {
@@ -101,12 +108,16 @@ module.exports = Backbone.View.extend(
       const config = this.config;
       const params = config.params;
 
-      for (let i = 0; i < files.length; i++) {
-        body.append(`${config.uploadName}[]`, files[i]);
-      }
-
       for (let param in params) {
         body.append(param, params[param]);
+      }
+
+      if (this.multiUpload) {
+        for (let i = 0; i < files.length; i++) {
+          body.append(`${config.uploadName}[]`, files[i]);
+        }
+      } else if (files.length) {
+        body.append(config.uploadName, files[0]);
       }
 
       var target = this.target;
@@ -229,6 +240,7 @@ module.exports = Backbone.View.extend(
           title: this.config.uploadText,
           uploadId: this.uploadId,
           disabled: this.disabled,
+          multiUpload: this.multiUpload,
           pfx: this.pfx
         })
       );

--- a/src/asset_manager/view/FileUploader.js
+++ b/src/asset_manager/view/FileUploader.js
@@ -122,7 +122,7 @@ module.exports = Backbone.View.extend(
         this.onUploadStart();
         return fetch(url, {
           method: 'post',
-          credentials: 'include',
+          credentials: config.credentials || 'include',
           headers,
           body
         })

--- a/test/specs/asset_manager/view/FileUploader.js
+++ b/test/specs/asset_manager/view/FileUploader.js
@@ -67,6 +67,18 @@ module.exports = {
           );
         });
 
+        test('Handles multiUpload false', () => {
+          var view = new FileUploader({
+            config: {
+              multiUpload: false
+            }
+          });
+          view.render();
+          expect(
+            view.$el.find('input[type=file]').prop('multiple')
+          ).toBeFalsy();
+        });
+
         test('Handles embedAsBase64 parameter', () => {
           var view = new FileUploader({
             config: {


### PR DESCRIPTION
This PR are the changes I had to make to support using an S3 bucket as the host server for assets.

- When using [S3 POST](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html) CORS means that permission is denied when including auth cookies so credentials must be set false.
- The endpoint only allows 1 file at a time and insists on the name of the file being `filename`. It cannot be `filename[]` so I added a multiUpload flag.
- The endpoint also insists on `key` being the first value in the the form so I moved the the files to after the params in body formdata.
- The endpoint returns an empty document which unsurprisingly is not valid JSON so I stuck that parse in a try catch.

Happy to provide an example/some docs for how to hook it up to S3 although its not trivial.

Thanks so much for a great project, couldn't believe how perfect it was for my needs when I found it!