### PR TITLE
Add component:clone propagation

### DIFF
--- a/src/dom_components/model/Component.js
+++ b/src/dom_components/model/Component.js
@@ -704,7 +704,11 @@ const Component = Backbone.Model.extend(Styleable).extend(
         attr.style = style;
       }
 
-      return new this.constructor(attr, opts);
+      const cloned = new this.constructor(attr, opts);
+      if (em) {
+        em.trigger('component:clone', cloned);
+      }
+      return cloned;
     },
 
     /**


### PR DESCRIPTION
Event `component:clone` should be propagated to it's children. Currently there is no way to distinguish between clone and create.

I would recommend against removing the `component:clone` event at [PasteComponent.js](https://github.com/artf/grapesjs/blob/dev/src/commands/view/PasteComponent.js) as that is triggered after the view is also initialized and might break previous functionality dependent on this behaviour.