### PR TITLE
Fix issue in Sorter when no canvasOffset is set

### DIFF
--- a/src/utils/Sorter.js
+++ b/src/utils/Sorter.js
@@ -79,8 +79,10 @@ module.exports = Backbone.View.extend({
    */
   udpateOffset() {
     var offset = this.em.get('canvasOffset');
-    this.offTop = offset.top;
-    this.offLeft = offset.left;
+    if (offset) {
+      this.offTop = offset.top;
+      this.offLeft = offset.left;
+    }
   },
 
   /**


### PR DESCRIPTION
I'm getting issues in my implementation where the ```udpateOffset``` function is called and there isn't a canvasOffset. 

Its not something I can reproduce in the demo and to be honest it seems random locally, but I have a feeling it could be coming from [here](https://github.com/artf/grapesjs/blob/738c536c80fb8fafe8ffbb86dda8ab1e1126a463/src/editor/model/Editor.js#L566)?