### PR TITLE
Fix parent to parent.length for stop while

### DIFF
--- a/src/commands/view/SelectComponent.js
+++ b/src/commands/view/SelectComponent.js
@@ -70,7 +70,7 @@ module.exports = {
 
     if (!model) {
       let parent = $el.parent();
-      while (!model && parent) {
+      while (!model && parent.length > 0) {
         model = parent.data('model');
         parent = parent.parent();
       }
@@ -183,7 +183,7 @@ module.exports = {
 
     if (!model) {
       let parent = $el.parent();
-      while (!model && parent) {
+      while (!model && parent.length > 0) {
         model = parent.data('model');
         parent = parent.parent();
       }


### PR DESCRIPTION
Hi !

If the wrapper is empty, an error is triggered on hover on the wrapper because the value checked is "parent" but after the "document" level, parent is an empty array so for resolve the error, you must check parent.length > 0

`
Uncaught TypeError: Cannot read property '_cash1549885089059' of undefined
    at getDataCache (grapes.js:6506)
    at getData (grapes.js:6514)
    at Init.data (grapes.js:6535)
    at child.onHover (grapes.js:28783)
    at executeBound (grapes.js:21273)
    at HTMLBodyElement.<anonymous> (grapes.js:21286)
    at HTMLBodyElement.<anonymous> (grapes.js:20633)
`