### PR TITLE
Add category on traits

### DIFF
--- a/src/selector_manager/view/ClassTagView.js
+++ b/src/selector_manager/view/ClassTagView.js
@@ -96,7 +96,8 @@ module.exports = require('backbone').View.extend({
     const { em, model } = this;
     const sel = em && em.getSelected();
     // Prevent weird erros on remove
-    sel && setTimeout(() => sel.getSelectors().remove(model));
+    if (!model.get('protected'))
+      sel && setTimeout(() => sel.getSelectors().remove(model));
   },
 
   /**

--- a/src/styles/scss/_gjs_traits.scss
+++ b/src/styles/scss/_gjs_traits.scss
@@ -34,3 +34,24 @@
     width: 70%;
   }
 }
+
+.#{$app-prefix}traits-categories {
+  display: flex;
+  flex-direction: column;
+}
+
+.#{$app-prefix}trait-category {
+  width: 100%;
+
+  &.#{$app-prefix}open {
+    @extend .#{$app-prefix}category-open;
+  }
+
+  .#{$app-prefix}title {
+    @extend .#{$app-prefix}category-title;
+  }
+
+  .#{$app-prefix}caret-icon {
+    margin-right: 5px;
+  }
+}

--- a/src/trait_manager/index.js
+++ b/src/trait_manager/index.js
@@ -1,11 +1,15 @@
 import { defaults, isElement } from 'underscore';
 
 const defaultOpts = require('./config/config');
+const Traits = require('./model/Traits');
 const TraitsView = require('./view/TraitsView');
+const TraitCategories = require('./model/Categories');
 
 module.exports = () => {
   let c = {};
   let TraitsViewer;
+  let traits, traitsVisible, traitsView;
+  let categories = [];
 
   return {
     TraitsView,
@@ -35,11 +39,43 @@ module.exports = () => {
       defaults(c, defaultOpts);
       const ppfx = c.pStylePrefix;
       ppfx && (c.stylePrefix = `${ppfx}${c.stylePrefix}`);
+      categories = new TraitCategories();
       TraitsViewer = new TraitsView({
         collection: [],
         editor: c.em,
-        config: c
+        config: c,
+        categories
       });
+
+      // Global blocks collection
+      traits = new Traits([]);
+      traitsVisible = new Traits([]);
+      categories = new TraitCategories();
+      traitsView = new TraitsView(
+        {
+          collection: traitsVisible,
+          editor: c.em,
+          config: c,
+          categories
+        },
+        c
+      );
+
+      // Setup the sync between the global and public collections
+      traits.listenTo(traits, 'add', model => {
+        traitsVisible.add(model);
+        em && em.trigger('trait:add', model);
+      });
+
+      traits.listenTo(traits, 'remove', model => {
+        traitsVisible.remove(model);
+        em && em.trigger('trait:remove', model);
+      });
+
+      traits.listenTo(traits, 'reset', coll => {
+        traitsVisible.reset(coll.models);
+      });
+
       return this;
     },
 
@@ -62,6 +98,43 @@ module.exports = () => {
     },
 
     /**
+     * Return all blocks
+     * @return {Collection}
+     * @example
+     * const blocks = blockManager.getAll();
+     * console.log(JSON.stringify(blocks));
+     * // [{label: 'Heading', content: '<h1>Put your ...'}, ...]
+     */
+    getAll() {
+      return traits;
+    },
+
+    /**
+     * Return the visible collection, which containes blocks actually rendered
+     * @return {Collection}
+     */
+    getAllVisible() {
+      return traitsVisible;
+    },
+
+    /**
+     * Remove a block by id
+     * @param {string} id Block id
+     * @return {Block} Removed block
+     */
+    remove(id) {
+      return traits.remove(id);
+    },
+
+    /**
+     * Return the Blocks container element
+     * @return {HTMLElement}
+     */
+    getContainer() {
+      return traitsView.el;
+    },
+
+    /**
      * Add new trait type
      * @param {string} name Type name
      * @param {Object} methods Object representing the trait
@@ -80,8 +153,42 @@ module.exports = () => {
       return TraitsViewer.itemsView[name];
     },
 
-    render() {
-      return TraitsViewer.render().el;
+    /**
+     * Get all available categories.
+     * It's possible to add categories only within blocks via 'add()' method
+     * @return {Array|Collection}
+     */
+    getCategories() {
+      return categories;
+    },
+
+    render(traits, opts = {}) {
+      const toRender = traits || this.getAll().models;
+
+      if (opts.external) {
+        return new TraitsView(
+          {
+            collection: new Traits(toRender),
+            editor: c.em,
+            config: c,
+            categories
+          },
+          {
+            ...c,
+            ...opts
+          }
+        ).render().el;
+      }
+
+      if (!TraitsViewer.rendered) {
+        TraitsViewer.render();
+        TraitsViewer.rendered = 1;
+      }
+
+      TraitsViewer.updateConfig(opts);
+      if (TraitsViewer.collection.length)
+        TraitsViewer.collection.reset(toRender);
+      return this.getContainer();
     }
   };
 };

--- a/src/trait_manager/model/Categories.js
+++ b/src/trait_manager/model/Categories.js
@@ -1,0 +1,5 @@
+import Backbone from 'backbone';
+
+module.exports = Backbone.Collection.extend({
+  model: require('./Category')
+});

--- a/src/trait_manager/model/Category.js
+++ b/src/trait_manager/model/Category.js
@@ -1,0 +1,10 @@
+import Backbone from 'backbone';
+
+module.exports = Backbone.Model.extend({
+  defaults: {
+    id: '',
+    label: '',
+    open: true,
+    attributes: {}
+  }
+});

--- a/src/trait_manager/model/Category.js
+++ b/src/trait_manager/model/Category.js
@@ -4,7 +4,7 @@ module.exports = Backbone.Model.extend({
   defaults: {
     id: '',
     label: '',
-    open: true,
+    open: false,
     attributes: {}
   }
 });

--- a/src/trait_manager/model/Trait.js
+++ b/src/trait_manager/model/Trait.js
@@ -13,6 +13,7 @@ module.exports = require('backbone').Model.extend({
     target: '',
     default: '',
     placeholder: '',
+    category: '',
     changeProp: 0,
     options: []
   },

--- a/src/trait_manager/view/CategoryView.js
+++ b/src/trait_manager/view/CategoryView.js
@@ -1,0 +1,81 @@
+import _ from 'underscore';
+import Backbone from 'backbone';
+
+module.exports = Backbone.View.extend({
+  template: _.template(`
+  <div class="<%= pfx %>title">
+    <i class="<%= pfx %>caret-icon"></i>
+    <%= label %>
+  </div>
+  <div class="<%= pfx %>blocks-c"></div>
+  `),
+
+  events: {},
+
+  initialize(o = {}, config = {}) {
+    this.config = config;
+    const pfx = this.config.pStylePrefix || '';
+    this.pfx = pfx;
+    this.caretR = 'fa fa-caret-right';
+    this.caretD = 'fa fa-caret-down';
+    this.iconClass = `${pfx}caret-icon`;
+    this.activeClass = `${pfx}open`;
+    this.className = `${pfx}block-category`;
+    this.events[`click .${pfx}title`] = 'toggle';
+    this.listenTo(this.model, 'change:open', this.updateVisibility);
+    this.delegateEvents();
+  },
+
+  updateVisibility() {
+    if (this.model.get('open')) this.open();
+    else this.close();
+  },
+
+  open() {
+    this.el.className = `${this.className} ${this.activeClass}`;
+    this.getIconEl().className = `${this.iconClass} ${this.caretD}`;
+    this.getBlocksEl().style.display = '';
+  },
+
+  close() {
+    this.el.className = this.className;
+    this.getIconEl().className = `${this.iconClass} ${this.caretR}`;
+    this.getBlocksEl().style.display = 'none';
+  },
+
+  toggle() {
+    var model = this.model;
+    model.set('open', !model.get('open'));
+  },
+
+  getIconEl() {
+    if (!this.iconEl) {
+      this.iconEl = this.el.querySelector('.' + this.iconClass);
+    }
+
+    return this.iconEl;
+  },
+
+  getBlocksEl() {
+    if (!this.blocksEl) {
+      this.blocksEl = this.el.querySelector('.' + this.pfx + 'blocks-c');
+    }
+
+    return this.blocksEl;
+  },
+
+  append(el) {
+    this.getBlocksEl().appendChild(el);
+  },
+
+  render() {
+    this.el.innerHTML = this.template({
+      pfx: this.pfx,
+      label: this.model.get('label')
+    });
+    this.el.className = this.className;
+    this.$el.css({ order: this.model.get('order') });
+    this.updateVisibility();
+    return this;
+  }
+});

--- a/src/trait_manager/view/CategoryView.js
+++ b/src/trait_manager/view/CategoryView.js
@@ -3,25 +3,25 @@ import Backbone from 'backbone';
 
 module.exports = Backbone.View.extend({
   template: _.template(`
-  <div class="<%= pfx %>title">
-    <i class="<%= pfx %>caret-icon"></i>
+  <div class="<%= ppfx %>title">
+    <i class="<%= ppfx %>caret-icon"></i>
     <%= label %>
   </div>
-  <div class="<%= pfx %>blocks-c"></div>
+  <div class="<%= pfx %>traits"></div>
   `),
 
   events: {},
 
   initialize(o = {}, config = {}) {
     this.config = config;
-    const pfx = this.config.pStylePrefix || '';
-    this.pfx = pfx;
+    this.pfx = config.stylePrefix || '';
+    this.ppfx = config.pStylePrefix || '';
     this.caretR = 'fa fa-caret-right';
     this.caretD = 'fa fa-caret-down';
-    this.iconClass = `${pfx}caret-icon`;
-    this.activeClass = `${pfx}open`;
-    this.className = `${pfx}block-category`;
-    this.events[`click .${pfx}title`] = 'toggle';
+    this.iconClass = `${this.ppfx}caret-icon`;
+    this.activeClass = `${this.ppfx}open`;
+    this.className = `${this.ppfx}trait-category`;
+    this.events[`click .${this.ppfx}title`] = 'toggle';
     this.listenTo(this.model, 'change:open', this.updateVisibility);
     this.delegateEvents();
   },
@@ -34,13 +34,13 @@ module.exports = Backbone.View.extend({
   open() {
     this.el.className = `${this.className} ${this.activeClass}`;
     this.getIconEl().className = `${this.iconClass} ${this.caretD}`;
-    this.getBlocksEl().style.display = '';
+    this.getTraitsEl().style.display = '';
   },
 
   close() {
     this.el.className = this.className;
     this.getIconEl().className = `${this.iconClass} ${this.caretR}`;
-    this.getBlocksEl().style.display = 'none';
+    this.getTraitsEl().style.display = 'none';
   },
 
   toggle() {
@@ -56,21 +56,22 @@ module.exports = Backbone.View.extend({
     return this.iconEl;
   },
 
-  getBlocksEl() {
+  getTraitsEl() {
     if (!this.blocksEl) {
-      this.blocksEl = this.el.querySelector('.' + this.pfx + 'blocks-c');
+      this.blocksEl = this.el.querySelector('.' + this.pfx + 'traits');
     }
 
     return this.blocksEl;
   },
 
   append(el) {
-    this.getBlocksEl().appendChild(el);
+    this.getTraitsEl().appendChild(el);
   },
 
   render() {
     this.el.innerHTML = this.template({
       pfx: this.pfx,
+      ppfx: this.ppfx,
       label: this.model.get('label')
     });
     this.el.className = this.className;

--- a/src/trait_manager/view/TraitsView.js
+++ b/src/trait_manager/view/TraitsView.js
@@ -1,3 +1,5 @@
+import { isString, isObject, bindAll } from 'underscore';
+
 const DomainViews = require('domain_abstract/view/DomainViews');
 const TraitView = require('./TraitView');
 const TraitSelectView = require('./TraitSelectView');
@@ -5,6 +7,7 @@ const TraitCheckboxView = require('./TraitCheckboxView');
 const TraitNumberView = require('./TraitNumberView');
 const TraitColorView = require('./TraitColorView');
 const TraitButtonView = require('./TraitButtonView');
+const CategoryView = require('./CategoryView');
 
 module.exports = DomainViews.extend({
   itemView: TraitView,
@@ -25,6 +28,11 @@ module.exports = DomainViews.extend({
     this.pfx = config.stylePrefix || '';
     this.ppfx = config.pStylePrefix || '';
     this.className = this.pfx + 'traits';
+    this.categories = o.categories || '';
+    this.renderedCategories = [];
+    this.noCatClass = `${this.ppfx}traits-no-cat`;
+    this.traitContClass = `${this.pfx}traits`;
+    this.catsClass = `${this.ppfx}traits-categories`;
     const toListen = 'component:toggled';
     this.listenTo(this.em, toListen, this.updatedCollection);
     this.updatedCollection();
@@ -37,8 +45,125 @@ module.exports = DomainViews.extend({
   updatedCollection() {
     const ppfx = this.ppfx;
     const comp = this.em.getSelected();
-    this.el.className = `${this.className} ${ppfx}one-bg ${ppfx}two-color`;
+    this.el.className = `${ppfx}one-bg ${ppfx}two-color`;
     this.collection = comp ? comp.get('traits') : [];
     this.render();
+  },
+
+  updateConfig(opts = {}) {
+    this.config = {
+      ...this.config,
+      ...opts
+    };
+  },
+
+  /**
+   * Add new model to the collection
+   * @param {Model} model
+   * @private
+   */
+  addTo(model) {
+    this.add(model);
+  },
+
+  /**
+   * Render new model inside the view
+   * @param {Model} model
+   * @param {Object} fragment Fragment collection
+   * @private
+   * */
+  add(model, fragment) {
+    const { config } = this;
+    var frag = fragment || null;
+    var itemView = this.itemView;
+    var typeField = model.get(this.itemType);
+    if (this.itemsView && this.itemsView[typeField]) {
+      itemView = this.itemsView[typeField];
+    }
+    var view = new itemView({
+      config,
+      model,
+      attributes: model.get('attributes')
+    });
+    var rendered = view.render().el;
+    var category = model.get('category');
+
+    // Check for categories
+    if (category && this.categories && !config.ignoreCategories) {
+      if (isString(category)) {
+        category = {
+          id: category,
+          label: category
+        };
+      } else if (isObject(category) && !category.id) {
+        category.id = category.label;
+      }
+
+      var catModel = this.categories.add(category);
+      var catId = catModel.get('id');
+      var catView = this.renderedCategories[catId];
+      var categories = this.getCategoriesEl();
+      model.set('category', catModel);
+
+      if (!catView && categories) {
+        catView = new CategoryView(
+          {
+            model: catModel
+          },
+          this.config
+        ).render();
+        this.renderedCategories[catId] = catView;
+        categories.appendChild(catView.el);
+      }
+
+      catView && catView.append(rendered);
+      return;
+    }
+
+    if (frag) frag.appendChild(rendered);
+    else this.append(rendered);
+  },
+
+  getCategoriesEl() {
+    if (!this.catsEl) {
+      this.catsEl = this.el.querySelector(`.${this.catsClass}`);
+    }
+
+    return this.catsEl;
+  },
+
+  getTraitsEl() {
+    if (!this.traitsEl) {
+      this.traitsEl = this.el.querySelector(
+        `.${this.noCatClass} .${this.traitContClass}`
+      );
+    }
+
+    return this.traitsEl;
+  },
+
+  append(el) {
+    let traits = this.getTraitsEl();
+    traits && traits.appendChild(el);
+  },
+
+  render() {
+    const ppfx = this.ppfx;
+    const frag = document.createDocumentFragment();
+    this.catsEl = null;
+    this.traitsEl = null;
+    this.renderedCategories = [];
+    this.el.innerHTML = `
+    <div class="${this.catsClass}"></div>
+    <div class="${this.noCatClass}">
+      <div class="${this.traitContClass}"></div>
+    </div>
+  `;
+    if (this.collection.length)
+      this.collection.each(model => this.add(model, frag));
+    this.append(frag);
+    const cls = `${ppfx}one-bg ${ppfx}two-color`;
+    this.$el.addClass(cls);
+    return this;
   }
 });


### PR DESCRIPTION
Hi !

We have added the possibility to make traits under categories like blocks. When you create a trait you can add a property like this

`
label: 'My trait',
type: 'text',
category: {
  id: 'general',
  label: 'General',
}
`

And the "My trait" trait will be make under the "General" category.

category propertie is optional and it's like the block category. (string or object)