### PR TITLE
[WIP] Icon rework

### DIFF
--- a/src/navigator/view/ItemView.js
+++ b/src/navigator/view/ItemView.js
@@ -1,6 +1,7 @@
 import { isUndefined, isString } from 'underscore';
 import { getModel } from 'utils/mixins';
 import Backbone from 'backbone';
+import icon from 'utils/icon';
 const ComponentView = require('dom_components/view/ComponentView');
 const inputProp = 'contentEditable';
 const $ = Backbone.$;
@@ -26,7 +27,7 @@ export default Backbone.View.extend({
     const addClass = !count ? this.clsNoChild : '';
     const clsTitle = `${this.clsTitle} ${addClass}`;
     const clsTitleC = `${this.clsTitleC} ${ppfx}one-bg`;
-    const clsCaret = `${this.clsCaret} fa fa-chevron-right`;
+    const clsCaret = this.clsCaret;
     const clsInput = `${this.inputNameCls} ${ppfx}no-app`;
     const level = this.level + 1;
     const gut = `${30 + level * 10}px`;
@@ -36,14 +37,16 @@ export default Backbone.View.extend({
       ${
         hidable
           ? `<i class="${pfx}layer-vis fa fa-eye ${
-              this.isVisible() ? '' : 'fa-eye-slash'
+              this.isVisible() ? '' : icon.eyeSlash()
             }" data-toggle-visible></i>`
           : ''
       }
       <div class="${clsTitleC}">
         <div class="${clsTitle}" style="padding-left: ${gut}" data-toggle-select>
           <div class="${pfx}layer-title-inn">
-            <i class="${clsCaret}" data-toggle-open></i>
+            <div data-toggle-open class="${clsCaret}">
+                ${icon.smartChevron()}
+            </div>
             ${model.getIcon()}
             <span class="${clsInput}" data-name>${name}</span>
           </div>
@@ -51,7 +54,7 @@ export default Backbone.View.extend({
       </div>
       <div class="${this.clsCount}">${count || ''}</div>
       <div class="${this.clsMove}" data-toggle-move>
-        <i class="fa fa-arrows"></i>
+         ${icon.arrows}
       </div>
       <div class="${this.clsChildren}"></div>`;
   },
@@ -96,12 +99,14 @@ export default Backbone.View.extend({
   },
 
   updateVisibility() {
+    console.log('updateVisibility');
     const pfx = this.pfx;
     const model = this.model;
     const hClass = `${pfx}layer-hidden`;
     const hideIcon = 'fa-eye-slash';
     const hidden = model.getStyle().display == 'none';
     const method = hidden ? 'addClass' : 'removeClass';
+    console.log(method, hideIcon);
     this.$el[method](hClass);
     this.getVisibilityEl()[method](hideIcon);
   },
@@ -171,15 +176,11 @@ export default Backbone.View.extend({
   updateOpening() {
     var opened = this.opt.opened || {};
     var model = this.model;
-    const chvDown = 'fa-chevron-down';
-
     if (model.get('open')) {
       this.$el.addClass('open');
-      this.getCaret().addClass(chvDown);
       opened[model.cid] = model;
     } else {
       this.$el.removeClass('open');
-      this.getCaret().removeClass(chvDown);
       delete opened[model.cid];
     }
   },

--- a/src/styles/scss/_gjs_icon.scss
+++ b/src/styles/scss/_gjs_icon.scss
@@ -1,0 +1,13 @@
+
+
+.icon-visible-open {
+  display: none;
+}
+
+.open .icon-visible-open {
+  display: inherit;
+}
+
+.open .icon-visible-not-open {
+  display: none;
+}

--- a/src/styles/scss/main.scss
+++ b/src/styles/scss/main.scss
@@ -7,6 +7,7 @@
 
 @import "gjs_variables.scss";
 
+@import "gjs_icon.scss";
 
 @font-face {
   font-family: 'font3336';
@@ -546,3 +547,4 @@ $colorsAll: (one, $primaryColor),
 .cm-s-hopscotch span.cm-error {
     color: #ffffff;
 }
+

--- a/src/utils/icon.js
+++ b/src/utils/icon.js
@@ -1,0 +1,19 @@
+export default {
+  eyeSlash: function() {
+    return 'ok';
+  },
+
+  arrows: '<i style="color: red;" class="fa fa-arrows"></i>',
+  chevronRight: '<i style="color: red;" class="fa fa-chevron-right"></i>',
+  chevronDown: '<i style="color: red;" class="fa fa-chevron-down"></i>',
+
+  /**
+   * Show
+   */
+  smartChevron: function() {
+    return `
+            <i class="fa fa-chevron-down icon-visible-open"></i>
+            <i class="fa fa-chevron-right icon-visible-not-open"></i>
+        `;
+  }
+};


### PR DESCRIPTION
I'm considering implementing GrapesJS in a web application and want to take a shot at implementing the icon rework, allowing us to move to other icon sets, versions or methods of inclusion.

I am an experienced developer, but have no experience in pure javascript or node development, so any feedback is appreciated.

This first commit contains several things:
1. It adds an `icon` helper that allows us to define icons in one place.
2. It adds a sass file for icon specific style rules, we will need these if we move to SVG icons. Currently it adds some helper classes.
3. It changes the way the caret in an item view is expanded; instead of using javascript it is now done using pure CSS.


The icon helper contains several icons defined in 2 ways: strings and functions. I need some guidance as to which makes most sense, personally I'd lean towards using a function, this way we can pass parameters used for icon generation in the future.
I've chosen to not have generic icon function but instead have a function per icon, this way the IDE can assist when using these icons.

I think it makes sense to not specify what icon we're using, but what we want to communicate, that way we have the design choices in one place. For example, currently I have the following icons:
- chevronRight
- chevronDown
- smartChevron

But when using these in the `ItemView` component I do not actually care that it is a chevron, if we redesign and want to use `+` and `-` then I don't want to change all usages.
Instead it makes more sense to have a `smartCollapsibleList()` icon that today returns the chevrons but can easily be changed later.
The same goes for the `eye` and `eye-slash` icons, it makes sense to abstract those and just have `smartVisibilityIndicator()`. 
In these examples smart refers to the fact that this icon will automatically change based on context, this will probably not work for all cases.

If you think what I'm saying makes (some) sense, and you're willing to steer me in the right direction I'm up for fully implementing this.

If up to me, this would be done in 2 steps.
1. Rework icon inclusion
2. Change icons to use a FA5 SVG sprite.

Step 1 would not result in any functional / visual changes.

Related to #644 