### PR TITLE
Fix plugins link on modules/Components.md

### DIFF
--- a/docs/modules/Components.md
+++ b/docs/modules/Components.md
@@ -440,5 +440,5 @@ Solution 1: turn off `autorender`
   editor.render();
 </script>
 ```
-Solution 2: put all the stuff inside a plugin ([Creating plugins](https://github.com/artf/grapesjs/wiki/Creating-plugins))
+Solution 2: put all the stuff inside a plugin ([Creating plugins](Plugins.html))
 


### PR DESCRIPTION
The plugin link is pointing at a GitHub page that immediately points back to the docs site, but it looks like it's been moved to this section.

Did a quick search of the codebase and didn't see a related issue or any open PRs that address this link change - 🤞that I've not duplicated work on this tiny link change.