### PR TITLE
Issue #2002 Resizer padding fix

### DIFF
--- a/src/commands/view/SelectComponent.js
+++ b/src/commands/view/SelectComponent.js
@@ -453,12 +453,11 @@ module.exports = {
           const style = modelToStyle.getStyle();
 
           if (!onlyHeight) {
-            const padding = 10;
             const frameOffset = canvas.getCanvasView().getFrameOffset();
             const width =
-              rect.w < frameOffset.width - padding
+              rect.w < frameOffset.width
                 ? rect.w
-                : frameOffset.width - padding;
+                : frameOffset.width;
             style[keyWidth] = autoWidth ? 'auto' : `${width}${unitWidth}`;
           }
 

--- a/src/commands/view/SelectComponent.js
+++ b/src/commands/view/SelectComponent.js
@@ -446,7 +446,8 @@ module.exports = {
             autoHeight,
             autoWidth,
             unitWidth,
-            unitHeight
+            unitHeight,
+            edgePadding
           } = config;
           const onlyHeight = ['tc', 'bc'].indexOf(selectedHandler) >= 0;
           const onlyWidth = ['cl', 'cr'].indexOf(selectedHandler) >= 0;
@@ -455,9 +456,9 @@ module.exports = {
           if (!onlyHeight) {
             const frameOffset = canvas.getCanvasView().getFrameOffset();
             const width =
-              rect.w < frameOffset.width
+              rect.w < frameOffset.width - edgePadding
                 ? rect.w
-                : frameOffset.width;
+                : frameOffset.width - edgePadding;
             style[keyWidth] = autoWidth ? 'auto' : `${width}${unitWidth}`;
           }
 

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -34,6 +34,9 @@ var defaultOpts = {
   // The key used for width resizing
   keyWidth: 'width',
 
+  // Number of pixels from the canvas edge to limit the resizer
+  edgePadding: 10,
+
   // If true, will override unitHeight and unitWidth, on start, with units
   // from the current focused element (currently used only in SelectComponent)
   currentUnit: 1,


### PR DESCRIPTION
Fixes #2002 

Pull #1736 added Resizer limit for canvas width.
10 pixels of padding was hard-coded in, presumably to stop Resizer handles from being moved partially outside the canvas. 
However, this padding removes the ability for a component to be resized to the width of the canvas, leaving a 10px gap, as per Issue 2002.

This pull adds the padding value to Resizer config, so the padding can be removed if need be, opt-out.