### PR TITLE
[Minor Fix] Can not add Button to a Panel that has not been initialized with a Button

### DIFF
--- a/src/panels/view/PanelView.js
+++ b/src/panels/view/PanelView.js
@@ -9,6 +9,7 @@ export default Backbone.View.extend({
     this.pfx = config.stylePrefix || '';
     this.ppfx = config.pStylePrefix || '';
     this.buttons = model.get('buttons');
+    this.buttonsViewRendered = false;
     this.className = this.pfx + 'panel';
     this.id = this.pfx + model.get('id');
     this.listenTo(model, 'change:appendContent', this.appendContent);
@@ -91,7 +92,7 @@ export default Backbone.View.extend({
           const keyWidth = config.keyWidth;
           const keyHeight = config.keyHeight;
           const rect = el.getBoundingClientRect();
-          const forContainer = target == 'container';
+          const forContainer = target === 'container';
           const styleWidth = style[keyWidth];
           const styleHeight = style[keyHeight];
           const width =
@@ -120,8 +121,9 @@ export default Backbone.View.extend({
     const cls = `${this.className} ${this.id} ${ppfx}one-bg ${ppfx}two-color`;
     $el.addClass(cls);
 
-    if (this.buttons.length) {
-      var buttons = new ButtonsView({
+    if (!this.buttonsViewRendered) {
+      this.buttonsViewRendered = true;
+      let buttons = new ButtonsView({
         collection: this.buttons,
         config: this.config
       });


### PR DESCRIPTION
While working with GrapesJS, I noticed, that you are unable to add buttons to a panel that is empty.

```js
let editor = grapesjs.init({
                               container: '#gjs',
                               height:    '600px',
                               width:     '800px',
                               panels:    {defaults: []},
                           });

let panelEl = document.createElement('div');
document.body.prepend(panelEl);
editor.Panels.addPanel({id: `testing-panel`, el: panelEl});
editor.Panels.addButton('testing-panel', {
    id:      'sw-visibility-button',
    command: 'sw-visibility',
    label:   '<i>Switch Visibility</i>',
    active:  false
});
```

This is caused by the ButtonsView not being created for a panel that has no buttons, and since no additional render call is happening when you add a button to the collection, the view remains absent.

I looks like that the if-statement in question was implemented to avoid rendering the buttons view multiple times, so I've changed it to use it's own property.