### PR TITLE
Compound selectors may no longer be extended

### DIFF
--- a/src/styles/scss/_gjs_selectors.scss
+++ b/src/styles/scss/_gjs_selectors.scss
@@ -3,7 +3,7 @@
 }
 
 .#{$clm-prefix}select {
-  @extend .#{$sm-prefix}field.#{$sm-prefix}select;
+  @extend .#{$sm-prefix}field, .#{$sm-prefix}select;
 }
 
 .#{$clm-prefix}tags {


### PR DESCRIPTION
- Dart Sass 1.0.0
- Ruby Sass 4.0.0

See https://sass-lang.com/documentation/breaking-changes