### PR TITLE
escape html characters when converting text node to HTML

### DIFF
--- a/src/dom_components/model/ComponentTextNode.js
+++ b/src/dom_components/model/ComponentTextNode.js
@@ -10,7 +10,12 @@ export default Component.extend(
     },
 
     toHTML() {
-      return this.get('content');
+      return this.get('content')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
     }
   },
   {

--- a/test/specs/dom_components/model/Component.js
+++ b/test/specs/dom_components/model/Component.js
@@ -3,6 +3,7 @@ import DomComponents from 'dom_components';
 import Component from 'dom_components/model/Component';
 import ComponentImage from 'dom_components/model/ComponentImage';
 import ComponentText from 'dom_components/model/ComponentText';
+import ComponentTextNode from 'dom_components/model/ComponentTextNode';
 import ComponentLink from 'dom_components/model/ComponentLink';
 import ComponentMap from 'dom_components/model/ComponentMap';
 import ComponentVideo from 'dom_components/model/ComponentVideo';
@@ -478,6 +479,36 @@ describe('Text Component', () => {
       content: 'test content'
     });
     expect(obj.toHTML()).toEqual('<div data-test="value">test content</div>');
+  });
+});
+
+describe('Text Node Component', () => {
+  beforeEach(() => {
+    obj = new ComponentTextNode();
+  });
+
+  afterEach(() => {
+    obj = null;
+  });
+
+  test('Has content property', () => {
+    expect(obj.has('content')).toEqual(true);
+  });
+
+  test('Not droppable', () => {
+    expect(obj.get('droppable')).toEqual(false);
+  });
+
+  test('Not editable', () => {
+    expect(obj.get('editable')).toEqual(true);
+  });
+
+  test('Component toHTML with attributes', () => {
+    obj = new ComponentTextNode({
+      attributes: { 'data-test': 'value' },
+      content: `test content &<>"'`
+    });
+    expect(obj.toHTML()).toEqual('test content &amp;&lt;&gt;&quot;&#039;');
   });
 });
 


### PR DESCRIPTION
When converting templates to HTML using the `component.toHTML()` function special characters are not escaped. This produces badly formed HTML.

Steps to reproduce:
 1. Go to https://grapesjs.com/demo.html
 1. Enter `<` into a text field
 1. In the dev console run the command `window.grapesjs.editors[0].getHtml()`

Expected Output:
Properly formed HTML with `<` character escaped

Actual Output:
`<` character left untouched and broken HTML

Please let me know if I missed anything here.

Keep up the great work!