### PR TITLE
Read avoidInlineStyle from config not from attributes

### DIFF
--- a/src/dom_components/view/ComponentView.js
+++ b/src/dom_components/view/ComponentView.js
@@ -208,7 +208,7 @@ export default Backbone.View.extend({
     const em = this.em;
     const model = this.model;
 
-    if (em && em.get('avoidInlineStyle')) {
+    if (em && em.getConfig('avoidInlineStyle')) {
       this.el.id = model.getId();
       const style = model.getStyle();
       !isEmpty(style) && model.setStyle(style);


### PR DESCRIPTION

If you change config after the initial configuration (like grapesjs-mjml does)
it wont be reflected on editor.attributes.avoidInlineStyle.
This means ComponentView in some cases will not respect the configuration.
    