### PR TITLE
Refreshing the visibility of the property, to avoid unwanted visible style options

### DIFF
--- a/src/style_manager/view/PropertiesView.js
+++ b/src/style_manager/view/PropertiesView.js
@@ -40,6 +40,7 @@ export default Backbone.View.extend({
     view.render();
     const rendered = view.el;
     this.properties.push(view);
+    view.updateVisibility();
 
     appendAtIndex(appendTo, rendered, opts.at);
   },


### PR DESCRIPTION
Hi @artf I hope you are having a great start of the year.

I've found out a small issue regarding the Style Manager. If the Style Manager panel is not set as  active on editor load and there's a property that has been setup as unstylable in any component, the property will still be visible but unable to make changes. 

I've added this line to avoid this issue, let me know if this has a better fit somewhere else.

Here are the steps to reproduce the issue I'm talking about:

**STEPS TO REPRODUCE**

1. Pull the last changes from the dev branch.
2. In src/panels/config.js, removed the active property from the style manager configuration.
3. In src/dom_components/model/Component.js, mark any currently visible property as unstylable, in my case I've added the 'float' property.
4. Reload the editor, select any component with the disabled property and open the style manager, the property will still be present but unable to make changes.


Let me know what you think.

Thanks!