### PR TITLE
Fix bug toggling preview

### DIFF
--- a/src/commands/view/Preview.js
+++ b/src/commands/view/Preview.js
@@ -49,7 +49,9 @@ export default {
     const { sender = {} } = this;
     sender.set && sender.set('active', 0);
     const panels = this.getPanels(editor);
-    editor.runCommand('sw-visibility');
+    if (editor.Panels.getButton("options","sw-visibility").attributes.active) {
+        editor.runCommand('sw-visibility');
+    }
     editor.getModel().runDefault();
     panels.style.display = '';
     const canvas = editor.Canvas.getElement();


### PR DESCRIPTION
Currently the component borders are turned on when you turn the preview off, regardless of what state the borders were in before. This change checks the button's active state to ensure the button was active before turning them on.