### PR TITLE
fix: replace static bg colors with scss var

### DIFF
--- a/src/styles/scss/_gjs_inputs.scss
+++ b/src/styles/scss/_gjs_inputs.scss
@@ -91,7 +91,7 @@
 }
 
 .#{$app-prefix}field {
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: $mainDkColor;
   border: none;
   box-shadow: none;
   border-radius: 2px;

--- a/src/styles/scss/_gjs_style_manager.scss
+++ b/src/styles/scss/_gjs_style_manager.scss
@@ -181,7 +181,7 @@
     }
 
     &.#{$sm-prefix}composite {
-      background-color: rgba(0, 0, 0, 0.1);
+      background-color: $mainDklColor;
       border: 1px solid rgba(0, 0, 0, 0.25);
     }
 


### PR DESCRIPTION
Hardcoded colors do not give the possibility to customize `StyleManager` styles:
<img width="416" alt="Screenshot 2020-03-09 at 11 32 18" src="https://user-images.githubusercontent.com/5191620/76200103-b59df380-61f9-11ea-8bc5-b1d0737676cb.png">

P.S: @artf
Please, let me know if it's required to change colors around all of the `.scss` files.
I change only those two, as I'm sure, that it would not affect the application so much.

Thank you, for merging this PR 🍻 