### PR TITLE
Fix borders not always toggling back when exiting preview. Fixes #2637

### DIFF
--- a/src/commands/view/Preview.js
+++ b/src/commands/view/Preview.js
@@ -18,7 +18,14 @@ export default {
   run(editor, sender) {
     this.sender = sender;
 
-    editor.stopCommand('sw-visibility');
+    if (!this.shouldRunSwVisibility) {
+      this.shouldRunSwVisibility = editor.Commands.isActive('sw-visibility');
+    }
+
+    if (this.shouldRunSwVisibility) {
+      editor.stopCommand('sw-visibility');
+    }
+
     editor.getModel().stopDefault();
 
     const panels = this.getPanels(editor);
@@ -54,13 +61,9 @@ export default {
     sender.set && sender.set('active', 0);
     const panels = this.getPanels(editor);
 
-    const swVisibilityButton = editor.Panels.getButton(
-      'options',
-      'sw-visibility'
-    );
-
-    if (swVisibilityButton && swVisibilityButton.get('active')) {
+    if (this.shouldRunSwVisibility) {
       editor.runCommand('sw-visibility');
+      this.shouldRunSwVisibility = false;
     }
 
     editor.getModel().runDefault();

--- a/src/commands/view/SwitchVisibility.js
+++ b/src/commands/view/SwitchVisibility.js
@@ -8,9 +8,12 @@ export default {
   },
 
   toggleVis(ed, active = 1) {
-    const method = active ? 'add' : 'remove';
-    ed.Canvas.getFrames().forEach(frame => {
-      frame.view.getBody().classList[method](`${this.ppfx}dashed`);
-    });
+    if (!ed.Commands.isActive('preview')) {
+      const method = active ? 'add' : 'remove';
+
+      ed.Canvas.getFrames().forEach(frame => {
+        frame.view.getBody().classList[method](`${this.ppfx}dashed`);
+      });
+    }
   }
 };

--- a/test/specs/commands/view/SwitchVisibility.js
+++ b/test/specs/commands/view/SwitchVisibility.js
@@ -1,0 +1,29 @@
+import SwitchVisibility from '../../../../src/commands/view/SwitchVisibility';
+
+describe('SwitchVisibility command', () => {
+  let fakeEditor, fakeFrames, fakeIsActive;
+
+  beforeEach(() => {
+    fakeFrames = [];
+    fakeIsActive = false;
+
+    fakeEditor = {
+      Canvas: {
+        getFrames: jest.fn(() => fakeFrames)
+      },
+
+      Commands: {
+        isActive: jest.fn(() => fakeIsActive)
+      }
+    };
+  });
+
+  describe('.toggleVis', () => {
+    it('should do nothing if the preview command is active', () => {
+      expect(fakeEditor.Canvas.getFrames).not.toHaveBeenCalled();
+      fakeIsActive = true;
+      SwitchVisibility.toggleVis(fakeEditor);
+      expect(fakeEditor.Canvas.getFrames).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
As described by [this issue](https://github.com/artf/grapesjs/issues/2637), the component borders may not be toggled back when exiting preview mode in some cases.

This fixes this issue by adding a `shouldRunSwVisibility` flag to the Preview command, set via the Commands API on its run (before stopping the `sw-visibility` command if it's active), & used on stop to reactivate the `sw-visibility` command if needed.

Which also implies:

- Prevent toggling of component borders while preview is active
- Rely on the Commands API to detect if the `sw-visibility` command is active rather than a panel button
- Prevent resetting the `shouldRunVisibility` flag on multiple subsequent (forced) runs / stops of the preview command