### PR TITLE
closing the color picker if click event happens on canvas, saving the current value

### DIFF
--- a/src/domain_abstract/ui/InputColor.js
+++ b/src/domain_abstract/ui/InputColor.js
@@ -117,6 +117,12 @@ export default Input.extend({
         }
       });
 
+      this.em &&
+        this.em.on('component:selected', () => {
+          changed = 1;
+          colorEl.spectrum('hide');
+        });
+
       this.colorEl = colorEl;
     }
     return this.colorEl;


### PR DESCRIPTION
Hi @artf, I hope are you well.

This is the fix for the color picker problem described some time ago here:

https://github.com/artf/grapesjs/issues/2467

Let me know if i can attach the hide function to a different event, at the moment i think is the best approach.

Thanks!  