### PR TITLE
Unable to use grapes' scss files in react project

### DIFF
--- a/src/styles/scss/main.scss
+++ b/src/styles/scss/main.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable */
-@import "node_modules/spectrum-colorpicker/spectrum";
-@import "node_modules/codemirror/lib/codemirror";
-@import "node_modules/codemirror/theme/hopscotch";
+@import "~spectrum-colorpicker/spectrum";
+@import "~codemirror/lib/codemirror";
+@import "~codemirror/theme/hopscotch";
 
 
 @import "gjs_variables.scss";


### PR DESCRIPTION
The following error occurs when compiling a react project:
```
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Can't find stylesheet to import.
  >  @import "node_modules/spectrum-colorpicker/spectrum";
  >  @import "node_modules/codemirror/lib/codemirror";
  >  @import "node_modules/codemirror/theme/hopscotch";
```

The file creating this is a scss file using `main.scss`:
```
@use '~grapesjs/src/styles/scss/main.scss';
@import '../fonts/MyFontsWebfontsKit.css';

$primaryColor: #444;
$secondaryColor: #ddd;
$tertiaryColor: #012f85;
$quaternaryColor: #23a543;
```

This is just a fix to make it work but the deprecated use of @import in grapesjs' sass files should also be considered (https://sass-lang.com/documentation/at-rules/import), don't you think so ?
