### PR TITLE
Checking if input is active in the main document as well as the frame.

### DIFF
--- a/src/canvas/index.js
+++ b/src/canvas/index.js
@@ -552,8 +552,12 @@ export default () => {
      */
     isInputFocused() {
       const doc = this.getDocument();
+      const frame = this.getFrameEl();
       const toIgnore = ['body', ...this.getConfig().notTextable];
-      const focused = doc && doc.activeElement;
+      const docActive = frame && document.activeElement === frame;
+      const focused = docActive
+        ? doc && doc.activeElement
+        : document.activeElement;
 
       return focused && !toIgnore.some(item => focused.matches(item));
     },

--- a/src/canvas/view/CanvasView.js
+++ b/src/canvas/view/CanvasView.js
@@ -92,7 +92,11 @@ export default Backbone.View.extend({
     const { em } = this;
     const key = getKeyChar(ev);
 
-    if (key === ' ' && em.getZoomDecimal() !== 1) {
+    if (
+      key === ' ' &&
+      em.getZoomDecimal() !== 1 &&
+      !em.get('Canvas').isInputFocused()
+    ) {
       this.preventDefault(ev);
       em.get('Editor').runCommand('core:canvas-move');
     }


### PR DESCRIPTION
Closes #2422

This checks if there is an active input in the main document as well as the frame. The onKeyPress function was trapping space bar presses in the editor and in the main document when the canvas was not at 100% zoom.