### PR TITLE
Fully clear hover state on mouseleave

### DIFF
--- a/src/commands/view/SelectComponent.js
+++ b/src/commands/view/SelectComponent.js
@@ -204,6 +204,8 @@ export default {
   onOut() {
     this.currentDoc = null;
     this.em.setHovered(0);
+    this.elHovered = undefined;
+    this.updateToolsLocal();
     this.canvas.getFrames().forEach(frame => {
       const { view } = frame;
       const el = view && view.getToolsEl();


### PR DESCRIPTION
"onOut" does not fully clear the internal state for hover elements.
This can result in drawing a previous hover element after mouseleave.

To reproduce this in the demo:
Open the demo with a browser in a smaller window, hover some items and drag resize the browser window.
The last hover item is drawn again after the resize.