### PR TITLE
[DOCS] fromElement should be disabled while loading templates

### DIFF
--- a/docs/modules/Storage.md
+++ b/docs/modules/Storage.md
@@ -83,6 +83,8 @@ const LandingPage = {
 // ...
 const editor = grapesjs.init({
   ...
+  // If set to true, then the content within the wrapper element overrides the following config,
+  fromElement: false,
   // The `components` accepts HTML string or a JSON of components
   // Here, at first, we check and use components if are already defined, otherwise
   // the HTML string gonna be used


### PR DESCRIPTION
When loading the template using init config, make sure the `fromElement: false` is set otherwise the content within the wrapper element will override the template config.