### PR TITLE
option to not cap slider value to max

### DIFF
--- a/src/domain_abstract/ui/InputNumber.js
+++ b/src/domain_abstract/ui/InputNumber.js
@@ -235,6 +235,8 @@ export default Input.extend({
     var unit = model.get('unit') || (units.length && units[0]) || '';
     var max = model.get('max');
     var min = model.get('min');
+    var limitlessMax = !!model.get('limitlessMax');
+    var limitlessMin = !!model.get('limitlessMin');
 
     if (opt.deepCheck) {
       var fixed = model.get('fixedValues') || [];
@@ -258,8 +260,10 @@ export default Input.extend({
       }
     }
 
-    if (!isUndefined(max) && max !== '') val = val > max ? max : val;
-    if (!isUndefined(min) && min !== '') val = val < min ? min : val;
+    if (!limitlessMax && !isUndefined(max) && max !== '')
+      val = val > max ? max : val;
+    if (!limitlessMax && !isUndefined(min) && min !== '')
+      val = val < min ? min : val;
 
     return {
       force,


### PR DESCRIPTION
Hi @artf I hope you are doing well.

I noticed something in the style manager, if you set a property as a slider and the element that is rendered has a calculated style value (e.g margin-top) greater than the slider max, the integer input appended to the slider also gets capped to the slider max instead of showing the real calculated value in the input.

I've added two attributes to bypass this behavior called limitlessMax and limitlessMin, let me know if you think there's better name for it.

In my custom repo i added this attribute to the margins and paddings properties, but i did not want to mess with the style property factory in the pull request.

Let me know what you think,

Kind regards,

Juan
