### PR TITLE
Fix bug `src` is stored twice in JSON stringification of ComponentImage. Closes #2913

### DIFF
--- a/src/dom_components/model/ComponentImage.js
+++ b/src/dom_components/model/ComponentImage.js
@@ -96,6 +96,21 @@ export default Component.extend(
     },
 
     /**
+     * Return a shallow copy of the model's attributes for JSON
+     * stringification.
+     * @return {Object}
+     * @private
+     */
+    toJSON(...args) {
+      const obj = Component.prototype.toJSON.apply(this, args);
+      if (obj.src === obj.attributes.src) {
+        delete obj.src;
+      }
+
+      return obj;
+    },
+
+    /**
      * Parse uri
      * @param  {string} uri
      * @return {object}

--- a/test/specs/dom_components/model/ComponentImage.js
+++ b/test/specs/dom_components/model/ComponentImage.js
@@ -8,6 +8,10 @@ describe('ComponentImage', () => {
     componentImage = new ComponentImage();
   });
 
+  test('`src` property is defined after initializing', () => {
+    expect(componentImage.get('src')).toBeDefined();
+  });
+
   describe('.getAttrToHTML', () => {
     let getSrcResultSpy;
     const fakeAttributes = {};


### PR DESCRIPTION
Fix #2913.