### PR TITLE
#3216 Set referrerPolicy to origin when loading image

### DIFF
--- a/src/asset_manager/view/AssetView.js
+++ b/src/asset_manager/view/AssetView.js
@@ -41,6 +41,7 @@ export default Backbone.View.extend({
     if (target && target.set) {
       target.set('attributes', clone(target.get('attributes')));
       target.set('src', this.model.get('src'));
+      target.set('referrerPolicy', 'origin');
     }
   },
 

--- a/src/dom_components/view/ComponentImageView.js
+++ b/src/dom_components/view/ComponentImageView.js
@@ -54,8 +54,9 @@ export default ComponentView.extend({
   updateSrc() {
     const { model, classEmpty, $el } = this;
     const src = model.getSrcResult();
+    const referrerPolicy = 'origin';
     const srcExists = src && !model.isDefaultSrc();
-    model.addAttributes({ src });
+    model.addAttributes({ src, referrerPolicy });
     $el[srcExists ? 'removeClass' : 'addClass'](classEmpty);
   },
 


### PR DESCRIPTION
This addition sends the `Referer` header when loading the image programmatically. With this addition it's possible to conform to referer checks introduced by eg. AWS WAF.

This PR solves https://github.com/artf/grapesjs/issues/3216