### PR TITLE
fix: box shadow blur default value

### DIFF
--- a/src/style_manager/model/PropertyFactory.js
+++ b/src/style_manager/model/PropertyFactory.js
@@ -237,7 +237,7 @@ export default () => ({
           obj.defaults = 1;
           break;
         case 'box-shadow-blur':
-          obj.defaults = '5px';
+          obj.defaults = '0px';
           break;
         case 'top':
         case 'right':

--- a/test/specs/style_manager/model/Models.js
+++ b/test/specs/style_manager/model/Models.js
@@ -925,7 +925,7 @@ describe('PropertyFactory', () => {
           property: 'box-shadow-blur',
           type: 'integer',
           units: ['px'],
-          defaults: '5px',
+          defaults: '0px',
           min: 0
         },
         {


### PR DESCRIPTION
This is to fix the bug: Cannot set 0px box shadow blur. Reference: #3267 