### PR TITLE
fix to script saving to be resilient if scripts contain comments

### DIFF
--- a/src/canvas/view/CanvasView.js
+++ b/src/canvas/view/CanvasView.js
@@ -299,7 +299,7 @@ export default Backbone.View.extend({
     const scriptFn = model.getScriptString();
     const scriptFnStr = model.get('script-props')
       ? scriptFn
-      : `function(){${scriptFn};}`;
+      : `function(){\n${scriptFn}\n;}`;
     const scriptProps = JSON.stringify(model.__getScriptProps());
     script.innerHTML = `
       setTimeout(function() {

--- a/src/code_manager/model/JsGenerator.js
+++ b/src/code_manager/model/JsGenerator.js
@@ -69,7 +69,7 @@ export default Backbone.Model.extend({
         code += `
           var items = document.querySelectorAll('${ids}');
           for (var i = 0, len = items.length; i < len; i++) {
-            (function(){${mapType.code}}.bind(items[i]))();
+            (function(){\n${mapType.code}\n}.bind(items[i]))();
           }`;
       }
     }


### PR DESCRIPTION
If a component script has javascript comments and is saved, there is a high risk of `Uncaught SyntaxError: Unexpected end of input` in `src/canvas/view/CanvasView.js:312` and the script will not be exported properly.

## Repro

Saving a script with comments e.g.
```javascript
let el = this // hi
```
or
```javascript
//let el = this
```

Digging deeper it looks like grapesjs is trying to append a script object with innerHTML of:

```javascript
innerHTML: "
      setTimeout(function() {
        var item = document.getElementById('i6x8e');
        if (!item) return;
        (function(){//let x=1333;}.bind(item))({})
      }, 1);"
```

and the comment inadvertently blows away the `.bind(...` portion of the script which was attached by Grapesjs.

Issue first discovered and described at https://github.com/Ju99ernaut/grapesjs-script-editor/issues/4

## The fix

By inserting newlines around the user script, we ensure comments will not blow away portions of the script which are attached by Grapesjs.  Viz

```javascript
innerHTML: "
      setTimeout(function() {
        var item = document.getElementById('i6x8e');
        if (!item) return;
        (function(){
//let x=1333
;}.bind(item))({})
      }, 1);"
```

## Reservations

- Not sure about the trailing `;` being added by Grapesjs?
- Tests not run.
- This is my first contribution to Grapesjs, so not sure about the deeper implications of this change. 
- Whilst I had to add the newlines fix in `src/code_manager/model/JsGenerator.js` to `build()` too, there remains another line of code in build() that probably needs it too line 64: `(${mapType.code}.bind(el))(props[el.id]);` but I haven't struck the need for it quite yet, so have left it.
