### PR TITLE
assign target in trait if its added in a target format

### DIFF
--- a/src/trait_manager/model/Traits.js
+++ b/src/trait_manager/model/Traits.js
@@ -1,5 +1,5 @@
 import Backbone from 'backbone';
-import { isString, isArray } from 'underscore';
+import { isString, isArray, isObject } from 'underscore';
 import Trait from './Trait';
 import TraitFactory from './TraitFactory';
 
@@ -30,6 +30,10 @@ export default Backbone.Collection.extend({
 
   add(models, opt) {
     const em = this.em;
+
+    if (isObject(models)) {
+      models.target = this.target;
+    }
 
     // Use TraitFactory if necessary
     if (isString(models) || isArray(models)) {


### PR DESCRIPTION
Hi @artf, I hope everything's good.

When I was trying to add a select trait dynamically as an object on a component, I've noticed that **getInputEl** of the **traitSelectView** tried to access the target with **model.getTargetValue()** and the target was not initialized yet, the target is assigned in the collection only if you pass the trait as an array or a string.

Let me know if i have to validate something else or add this action in another file. 

Thanks!
