### PR TITLE
Spelling error in GitHub issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -28,7 +28,7 @@ READ and FOLLOW next 3 steps, then REMOVE them before posting the issue
 
 **What is the current behavior?**
 
-*Descripe the bug **detailed***
+*Describe the bug **detailed***
 
 **Are you able to attach screenshots, screencasts or a live demo?**
 

--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -19,8 +19,8 @@ READ and FOLLOW next 3 steps, then REMOVE them before posting the issue
 
 **Are you able to reproduce the bug from the demo?**
 
-[ ] Yes
-[ ] No
+ - [ ] Yes
+ - [ ] No
 
 **What is the expected behavior?**
 
@@ -32,5 +32,5 @@ READ and FOLLOW next 3 steps, then REMOVE them before posting the issue
 
 **Are you able to attach screenshots, screencasts or a live demo?**
 
-[ ] Yes (attach)
-[ ] No
+ - [ ] Yes (attach)
+ - [ ] No

--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -19,7 +19,7 @@ READ and FOLLOW next 3 steps, then REMOVE them before posting the issue
 
 **Is there an alternative at the latest version?**
 
-[ ] Yes (descripe the alternative)
+[ ] Yes (describe the alternative)
 [ ] No
 
 **Is this related to an issue?**

--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -19,10 +19,10 @@ READ and FOLLOW next 3 steps, then REMOVE them before posting the issue
 
 **Is there an alternative at the latest version?**
 
-[ ] Yes (describe the alternative)
-[ ] No
+ - [ ] Yes (describe the alternative)
+ - [ ] No
 
 **Is this related to an issue?**
 
-[ ] Yes (Give a link to the issue)
-[ ] No
+ - [ ] Yes (Give a link to the issue)
+ - [ ] No


### PR DESCRIPTION
Spelling error of "describe" from "descripe". Additionally, changed the checkboxes to actual GitHub markdown syntax task lists.