### PR TITLE
Set width of side panel to 20% (Fixes #3312)

### DIFF
--- a/src/styles/scss/_gjs_variables.scss
+++ b/src/styles/scss/_gjs_variables.scss
@@ -41,7 +41,7 @@ $colorGreen:        #62c462 !default;
 $tagBg:             #804f7b !default;
 $secColor:          $tagBg !default;
 $imageCompDim:      50px !default;
-$leftWidth:         15% !default;
+$leftWidth:         20% !default;
 
 /* Color Helpers */
 $colorHighlight:    #71b7f1 !default;


### PR DESCRIPTION
Sets the width of the side panel to 20% so the panel with all the blocks doesn't look scrunched up on a medium sized (browser) screen.

I'm also thinking about when all three side panel options are not selected, the side panel is hidden. Kinda of like a preview view but you can still drag the blocks.