### PR TITLE
Fixes german translation for word "layer"

### DIFF
--- a/src/i18n/locale/de.js
+++ b/src/i18n/locale/de.js
@@ -72,7 +72,7 @@ export default {
   styleManager: {
     empty:
       "Wählen Sie ein Element aus bevor Sie den Stil Manager nutzen",
-    layer: 'Evene',
+    layer: 'Ebene',
     fileButton: 'Bilder',
     sectors: {
       general: 'Allgemein',


### PR DESCRIPTION
This PR fixes the wrong translation of the word "layer" in the german locale file.

Closes #3320 