### PR TITLE
Add loading attributes for images

### DIFF
--- a/src/dom_components/model/ComponentImage.js
+++ b/src/dom_components/model/ComponentImage.js
@@ -15,7 +15,18 @@ export default Component.extend(
       editable: 1,
       highlightable: 0,
       resizable: { ratioDefault: 1 },
-      traits: ['alt'],
+      traits: [
+        'alt',
+        {
+          type: 'select',
+          name: 'loading',
+          label: 'Loading',
+          options: [
+            { id: 'lazy', name: 'Lazy' },
+            { id: 'eager', name: 'Eager' }
+          ]
+        }
+      ],
 
       src: `<svg ${svgAttrs}>
         <path d="M8.5 13.5l2.5 3 3.5-4.5 4.5 6H5m16 1V5a2 2 0 0 0-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2z"></path>


### PR DESCRIPTION
In latest browsers, images can be lazily loaded by using `loading="lazy"` attribute. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img

Fixes #3427