### PR TITLE
Edit-only selectors feature

### DIFF
--- a/src/code_manager/model/CssGenerator.js
+++ b/src/code_manager/model/CssGenerator.js
@@ -107,19 +107,22 @@ export default Backbone.Model.extend({
     const selectorStrNoAdd = rule.selectorsToString({ skipAdd: 1 });
     const selectorsAdd = rule.get('selectorsAdd');
     const singleAtRule = rule.get('singleAtRule');
-    let found;
 
-    // This will not render a rule if there is no its component
-    rule.get('selectors').each(selector => {
-      const name = selector.getFullName();
-      if (
-        this.compCls.indexOf(name) >= 0 ||
-        this.ids.indexOf(name) >= 0 ||
-        opts.keepUnusedStyles
-      ) {
-        found = 1;
-      }
-    });
+    const selectors = rule.get('selectors').models;
+
+    // This rule will render in case:
+    // * all of selectors are not editonly
+    // * if some component is using the rule or keepUnusedStyles is enabled
+    const found =
+      selectors.every(s => !s.get('editonly')) &&
+      selectors.some(s => {
+        const name = s.getFullName();
+        return (
+          this.compCls.indexOf(name) >= 0 ||
+          this.ids.indexOf(name) >= 0 ||
+          opts.keepUnusedStyles
+        );
+      });
 
     if ((selectorStrNoAdd && found) || selectorsAdd || singleAtRule) {
       const block = rule.getDeclaration({ body: 1 });

--- a/src/dom_components/model/Component.js
+++ b/src/dom_components/model/Component.js
@@ -565,9 +565,13 @@ const Component = Backbone.Model.extend(Styleable).extend(
 
       // Add classes
       if (!opts.noClass) {
-        this.get('classes').forEach(cls =>
-          classes.push(isString(cls) ? cls : cls.get('name'))
-        );
+        this.get('classes').forEach(cls => {
+          if (isString(cls)) {
+            classes.push(cls);
+          } else if (!opts.forHTML || !cls.get('editonly')) {
+            classes.push(cls.get('name'));
+          }
+        });
         classes.length && (attributes.class = classes.join(' '));
       }
 
@@ -1382,7 +1386,7 @@ const Component = Backbone.Model.extend(Styleable).extend(
      * @private
      */
     getAttrToHTML() {
-      var attr = this.getAttributes();
+      var attr = this.getAttributes({ forHTML: true });
       delete attr.style;
       return attr;
     },

--- a/src/selector_manager/model/Selector.js
+++ b/src/selector_manager/model/Selector.js
@@ -25,7 +25,11 @@ const Selector = Model.extend(
       private: false,
 
       // If true, can't be removed from the attacched element
-      protected: false
+      protected: false,
+
+      // If true, selector is applied only inside editor
+      // Will not be present in export code
+      editonly: false
     },
 
     initialize(props, opts = {}) {


### PR DESCRIPTION
Sometimes I need to mark specific selectors as edit-only, which means that they should not be rendered for output. More specifically, if selector editonly attribute is true, then Css/Html code generators will not include the rule associated with the selector.