### PR TITLE
Fix left position of rteToolbarPosUpdate

### DIFF
--- a/src/rich_text_editor/index.js
+++ b/src/rich_text_editor/index.js
@@ -281,7 +281,7 @@ export default () => {
       });
 
       style.top = pos.top + un;
-      style.left = 0 + un;
+      style.left = pos.left + un;
     },
 
     /**


### PR DESCRIPTION
With this patch, the RTE position as modified by "rteToolbarPosUpdate" (see for example https://github.com/artf/grapesjs-plugin-ckeditor/blob/master/src/index.js#L121-L142) is now applied instead of thrown away.