### PR TITLE
Selector manager auto suggest for existing selectors

### DIFF
--- a/src/selector_manager/view/ClassTagsView.js
+++ b/src/selector_manager/view/ClassTagsView.js
@@ -408,7 +408,9 @@ export default Backbone.View.extend({
       return selector.get('name');
     });
     allSelectors.forEach(selectors => {
-      selectorOptions += `<option value="${selectors.get('name')}"></option>`;
+      selectorOptions += `<option value="${selectors.get(
+        'name'
+      )}">${selectors.get('name')}</option>`;
     });
     const classList = this.el.querySelector('[data-selector-list]');
     classList.innerHTML = selectorOptions;

--- a/test/specs/selector_manager/view/ClassTagsView.js
+++ b/test/specs/selector_manager/view/ClassTagsView.js
@@ -308,4 +308,23 @@ describe('ClassTagsView', () => {
       expect(view.$el.find('#states')[0]).toBeTruthy();
     });
   });
+
+  describe('getAllSelectors', () => {
+    test('Data list should be empty', () => {
+      view.getAllSelectors();
+      expect(view.$el.find('[data-selector-list]')[0].children.length).toEqual(
+        0
+      );
+    });
+
+    test('Data list should be have children option', () => {
+      const selectorManager = target.get('SelectorManager');
+      const mockSelector = 'testSelector';
+      selectorManager.add(mockSelector);
+      view.getAllSelectors();
+      expect(view.$el.find('[data-selector-list]')[0].children[0].text).toEqual(
+        mockSelector
+      );
+    });
+  });
 });


### PR DESCRIPTION
Hi @artf, 

This PR add feature for selector auto-suggest, with  adding `data-list` on selector manager then fetch all existing selectors. Will append the fetched selectors for auto-suggest on data-input.

Related discussion: https://github.com/artf/grapesjs/discussions/3890

<img width="421" alt="Screen Shot 2021-10-25 at 9 14 56 PM" src="https://user-images.githubusercontent.com/29661216/138703073-a68b2059-331c-405a-9e30-cab75d006491.png">