### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -179,7 +179,7 @@ Read more about this in [Define New Component][17]
 
 *   `type` **[string][15]** Component ID
 
-Returns **[Object][12]** Component type defintion, eg. `{ model: ..., view: ... }`
+Returns **[Object][12]** Component type definition, eg. `{ model: ..., view: ... }`
 
 ## removeType
 

--- a/docs/modules/Commands.md
+++ b/docs/modules/Commands.md
@@ -264,7 +264,7 @@ The Commands module offers also a set of events that you can use to intercept th
 
 ### Intercept run and stop
 
-By using our previosly created `my-command-modal` command let's see which events we can listen to
+By using our previously created `my-command-modal` command let's see which events we can listen to
 
 ```js
 editor.on('run:my-command-modal', () => {

--- a/docs/modules/Components.md
+++ b/docs/modules/Components.md
@@ -872,7 +872,7 @@ If you want to know how to create Components with javascript attached (eg. count
 If you're importing big chunks of HTML string into the editor (eg. defined via Blocks) JSX might be a great compromise between perfomances and code readibility as it allows you to skip the parsing and the component recognition steps by keeping the HTML syntax.
 By default, GrapesJS understands objects generated from React JSX preset, so, if you're working in the React app probably you're already using JSX and you don't need to do anything else, your environment is already configured to parse JSX in javascript files.
 
-So, intead of writing this:
+So, instead of writing this:
 ```js
 // I'm adding a string, so the parsing and the component recognition steps will be executed
 editor.addComponents(`<div>

--- a/src/dom_components/config/config.js
+++ b/src/dom_components/config/config.js
@@ -15,7 +15,7 @@ export default {
   storeWrapper: 0,
 
   /**
-   * You can setup a custom component definiton processor before adding it into the editor.
+   * You can setup a custom component definition processor before adding it into the editor.
    * It might be useful to transform custom objects (es. some framework specific JSX) to GrapesJS component one.
    * This custom function will be executed on ANY new added component to the editor so make smart checks/conditions
    * to avoid doing useless executions

--- a/src/dom_components/index.js
+++ b/src/dom_components/index.js
@@ -564,7 +564,7 @@ export default () => {
      * Get component type.
      * Read more about this in [Define New Component](https://grapesjs.com/docs/modules/Components.html#define-new-component)
      * @param {string} type Component ID
-     * @return {Object} Component type defintion, eg. `{ model: ..., view: ... }`
+     * @return {Object} Component type definition, eg. `{ model: ..., view: ... }`
      */
     getType(type) {
       var df = componentTypes;

--- a/src/dom_components/model/Component.js
+++ b/src/dom_components/model/Component.js
@@ -844,7 +844,7 @@ export default class Component extends Model.extend(Styleable) {
           addedInstances: addedInstances.map(c => c.cid),
           added: m.cid
         });
-      // Here, before appending a new symbol, I have to ensure there are no previosly
+      // Here, before appending a new symbol, I have to ensure there are no previously
       // created symbols (eg. used mainly when drag components around)
       toUp.forEach(symb => {
         const symbTop = symb.__getSymbTop();

--- a/src/navigator/config/config.js
+++ b/src/navigator/config/config.js
@@ -26,7 +26,7 @@ export default {
 
   // Scroll to selected component in Canvas when it's selected in Layers
   // true, false or `scrollIntoView`-like options,
-  // `block: 'nearest'` avoids the issue of window scolling
+  // `block: 'nearest'` avoids the issue of window scrolling
   scrollCanvas: { behavior: 'smooth', block: 'nearest' },
 
   // Scroll to selected component in Layers when it's selected in Canvas

--- a/src/storage_manager/config/config.js
+++ b/src/storage_manager/config/config.js
@@ -59,7 +59,7 @@ export default {
 
   // Pass custom options to fetch API (remote storage)
   // You can pass a simple object: { someOption: 'someValue' }
-  // or a function wich returns and object to add:
+  // or a function which returns and object to add:
   // currentOpts => {
   //  return currentOpts.method === 'post' ?  { method: 'patch' } : {};
   // }

--- a/src/utils/Sorter.js
+++ b/src/utils/Sorter.js
@@ -854,7 +854,7 @@ export default Backbone.View.extend({
   /**
    * Get children dimensions
    * @param {HTMLELement} el Element root
-   * @retun {Array}
+   * @return {Array}
    * */
   getChildrenDim(trg) {
     const dims = [];
@@ -920,7 +920,7 @@ export default Backbone.View.extend({
    * @param {Array<Array>} dims Dimensions of nodes to parse
    * @param {number} posX X coordindate
    * @param {number} posY Y coordindate
-   * @retun {Object}
+   * @return {Object}
    * */
   findPosition(dims, posX, posY) {
     var result = { index: 0, indexEl: 0, method: 'before' };

--- a/test/specs/grapesjs/index.js
+++ b/test/specs/grapesjs/index.js
@@ -506,7 +506,7 @@ describe('GrapesJS', () => {
         editor.selectToggle([el1, el2, el3]);
         expect(editor.getSelected()).toBe(el2);
         expect(editor.getSelectedAll().length).toBe(2);
-        // Add mutiple
+        // Add multiple
         editor.selectAdd([el2, el3]);
         expect(editor.getSelected()).toBe(el3);
         expect(editor.getSelectedAll().length).toBe(3);


### PR DESCRIPTION
There are small typos in:
- docs/api/components.md
- docs/modules/Commands.md
- docs/modules/Components.md
- src/dom_components/config/config.js
- src/dom_components/index.js
- src/dom_components/model/Component.js
- src/navigator/config/config.js
- src/storage_manager/config/config.js
- src/utils/Sorter.js
- test/specs/grapesjs/index.js

Fixes:
- Should read `return` rather than `retun`.
- Should read `previously` rather than `previosly`.
- Should read `definition` rather than `defintion`.
- Should read `which` rather than `wich`.
- Should read `scrolling` rather than `scolling`.
- Should read `multiple` rather than `mutiple`.
- Should read `instead` rather than `intead`.
- Should read `definition` rather than `definiton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md