### PR TITLE
remove traces of removed canvasScroll event

### DIFF
--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -124,7 +124,6 @@ Check the [Pages][8] module.
 
 ### General
 
-*   `canvasScroll` - Canvas is scrolled
 *   `update` - The structure of the template is updated (its HTML/CSS)
 *   `undo` - Undo executed
 *   `redo` - Redo executed

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -90,7 +90,6 @@
  * ### Pages
  * Check the [Pages](/api/pages.html) module.
  * ### General
- * * `canvasScroll` - Canvas is scrolled
  * * `update` - The structure of the template is updated (its HTML/CSS)
  * * `undo` - Undo executed
  * * `redo` - Redo executed

--- a/src/rich_text_editor/index.js
+++ b/src/rich_text_editor/index.js
@@ -34,7 +34,7 @@ export default () => {
   let config = {};
   let toolbar, actions, lastEl, lastElPos, globalRte;
   const eventsUp =
-    'change:canvasOffset canvasScroll frame:scroll component:update';
+    'change:canvasOffset frame:scroll component:update';
   const hideToolbar = () => {
     const style = toolbar.style;
     const size = '-1000px';


### PR DESCRIPTION
As far as I can tell, canvasScroll was removed in 11392dd67a9c68ac3fca13c236d3e01e5ede6e9c.
This commit removes the leftover traces of the event from the docs and the RTE handler.