### PR TITLE
Allow for the title of a block to be passed as an attribute

### DIFF
--- a/src/block_manager/view/BlockView.js
+++ b/src/block_manager/view/BlockView.js
@@ -128,7 +128,7 @@ export default Backbone.View.extend({
       ${media ? `<div class="${className}__media">${media}</div>` : ''}
       <div class="${className}-label">${label}</div>
     `;
-    el.title = el.textContent.trim();
+    el.title = attr.title || el.textContent.trim();
     el.setAttribute('draggable', hasDnd(em) && !disable ? true : false);
     const result = render && render({ el, model, className, prefix: ppfx });
     if (result) el.innerHTML = result;


### PR DESCRIPTION
The documentation seems to suggest that this should already be possible, but currently the title passed as an attribute is ignored.

https://grapesjs.com/docs/api/block_manager.html#add