### PR TITLE
Fix race condition in CssComposer loading.

### DIFF
--- a/src/css_composer/index.js
+++ b/src/css_composer/index.js
@@ -134,9 +134,9 @@ export default () => {
       }
 
       if (isArray(obj)) {
-        obj.length && rules.reset(obj);
+        obj.length && rules.add(obj);
       } else if (obj) {
-        rules.reset(obj);
+        rules.add(obj);
       }
 
       return obj;


### PR DESCRIPTION
At the time the load() function is called, the CssComposer could already have some rules added to it.

When loading a grapes definition with inline styles, it is possible that some of the inline-defined CSS rules are overwritten by the CssComposer load. This is because CssComposer->load reset the rules on load.

The race is between the components loader already adding new rules to CssComposer before CssComposer->load is being called.

I could only reliably reproduce the bug on slow internet connections (using Chrome Dev Tools, I had to simulate a slow 3G connection to make it happen reliably). It is also important that some of the components being loaded the earliest have some inline style to them, like this:
```
[
  {
    "type": "my-wrapper",
    "components": [
      // ...
    ],
    "style": {
      "__bg-type": "color",
      "background-image": "linear-gradient(#FF0000,#FF0000)",
      "background-repeat": "repeat",
      "background-position": "left top",
      "background-attachment": "scroll",
      "background-size": "auto"
    }
  }
]

```

The order of CssComposer function calls is sometimes like this, which produces a good result:
 * load()
 * setIdRule
 * setIdRule
 * // ...

But sometimes it is also like this, which leads to the first two rules being deleted:
  * setIdRule
  * setIdRule
  * load
  * setIdRule
  * // ...


The reason I'm explaining this in so much detail is that I don't know if the same problem can also be found in other parts of grapes. I am not sure what side effects (other than adding css rules) the loading of components might have; which are later overwritten by forceful resetting in the load function.
For example, #3589 could be related. While investigating this problem, the loading *always* worked correctly with a hard refresh, but failed relatively often with a normal refresh.