### PR TITLE
Fix empty scrips gen

### DIFF
--- a/src/code_manager/model/JsGenerator.js
+++ b/src/code_manager/model/JsGenerator.js
@@ -39,7 +39,7 @@ export default Backbone.Model.extend({
       }
     }
 
-    comps.each(function(model) {
+    comps.each(function (model) {
       code += this.mapModel(model);
     }, this);
 
@@ -55,7 +55,8 @@ export default Backbone.Model.extend({
       const mapType = this.mapJs[type];
 
       if (mapType.props) {
-        code += `
+        if (mapType.code && mapType.code.trim()) {
+          code += `
           var props = ${JSON.stringify(mapType.props)};
           var ids = Object.keys(props).map(function(id) { return '#'+id }).join(',');
           var els = document.querySelectorAll(ids);
@@ -63,17 +64,20 @@ export default Backbone.Model.extend({
             var el = els[i];
             (${mapType.code}.bind(el))(props[el.id]);
           }`;
+        }
       } else {
         // Deprecated
-        const ids = '#' + mapType.ids.join(', #');
-        code += `
+        if (mapType.code && mapType.code.trim()) {
+          const ids = '#' + mapType.ids.join(', #');
+          code += `
           var items = document.querySelectorAll('${ids}');
           for (var i = 0, len = items.length; i < len; i++) {
             (function(){\n${mapType.code}\n}.bind(items[i]))();
           }`;
+        }
       }
     }
 
     return code;
-  }
+  },
 });


### PR DESCRIPTION
Components with an empty script in definition produce unnecessary js in output.
A component defined like:
```js
model: ...
 defaults {
  script: () => {}
 }
```
When used and scripts are exported this results in something like:
![image](https://user-images.githubusercontent.com/10260230/153754449-04fc5a54-bb27-4893-a4ce-8841f470be36.png)

We can skip this in cases of scripts's content being either whitespace only or a falsy value.
