### PR TITLE
fix issue#4236:  added validity check before pasting

### DIFF
--- a/src/commands/view/PasteComponent.js
+++ b/src/commands/view/PasteComponent.js
@@ -17,7 +17,7 @@ export default {
         const at = coll.indexOf(comp) + 1;
         const addOpts = { at, action: opts.action || 'paste-component' };
         const copyable = clp.filter(cop => cop.get('copyable'));
-        const pasteable = copyable.filter(cop => editor.Components.canMove(comp.parent(), cop).result);
+        const pasteable = copyable.filter(cop => ed.Components.canMove(comp.parent(), cop).result);
 
         if (contains(clp, comp) && comp.get('copyable')) {
           added = coll.add(comp.clone(), addOpts);

--- a/src/commands/view/PasteComponent.js
+++ b/src/commands/view/PasteComponent.js
@@ -5,6 +5,7 @@ export default {
     const em = ed.getModel();
     const clp = em.get('clipboard');
     const selected = ed.getSelected();
+    const sorter = ed.BlockManager.getConfig().getSorter();
 
     if (clp && selected) {
       ed.getSelectedAll().forEach(comp => {
@@ -13,16 +14,20 @@ export default {
         const coll = comp.collection;
         if (!coll) return;
 
+        let added;
         const at = coll.indexOf(comp) + 1;
         const addOpts = { at, action: opts.action || 'paste-component' };
         const copyable = clp.filter(cop => cop.get('copyable'));
-        let added;
+        const pasteable = copyable.filter(cop => {
+              return sorter.validTarget(cop.getEl(), selected.getEl()).valid
+                  || sorter.validTarget(cop.parent()?.getEl(), selected.getEl()).valid;
+          });
 
         if (contains(clp, comp) && comp.get('copyable')) {
           added = coll.add(comp.clone(), addOpts);
         } else {
           added = coll.add(
-            copyable.map(cop => cop.clone()),
+            pasteable.map(cop => cop.clone()),
             addOpts
           );
         }

--- a/src/commands/view/PasteComponent.js
+++ b/src/commands/view/PasteComponent.js
@@ -5,7 +5,6 @@ export default {
     const em = ed.getModel();
     const clp = em.get('clipboard');
     const selected = ed.getSelected();
-    const sorter = ed.BlockManager.getConfig().getSorter();
 
     if (clp && selected) {
       ed.getSelectedAll().forEach(comp => {
@@ -18,10 +17,7 @@ export default {
         const at = coll.indexOf(comp) + 1;
         const addOpts = { at, action: opts.action || 'paste-component' };
         const copyable = clp.filter(cop => cop.get('copyable'));
-        const pasteable = copyable.filter(cop => {
-              return sorter.validTarget(cop.getEl(), selected.getEl()).valid
-                  || sorter.validTarget(cop.parent()?.getEl(), selected.getEl()).valid;
-          });
+        const pasteable = copyable.filter(cop => editor.Components.canMove(comp.parent(), cop).result);
 
         if (contains(clp, comp) && comp.get('copyable')) {
           added = coll.add(comp.clone(), addOpts);


### PR DESCRIPTION
Using sorter to test for validity if:
- component can be pasted inside selection
- component can be pasted inside parent of selection

Should fix [issue #4236](https://github.com/artf/grapesjs/issues/4236)