### PR TITLE
Fix on generated css for transform property

### DIFF
--- a/src/style_manager/model/Property.js
+++ b/src/style_manager/model/Property.js
@@ -364,7 +364,8 @@ export default class Property extends Model {
    */
   getFullValue(val) {
     const fn = this.get('functionName');
-    const def = this.getDefaultValue();
+    const fnOnDef = this.get('applyFunctionOnDefault');
+    const def = fn && fnOnDef ? `${fn}(${this.getDefaultValue()})` : this.getDefaultValue();
     let value = isUndefined(val) ? this.get('value') : val;
     const hasValue = !isUndefined(value) && value !== '';
 
@@ -489,6 +490,9 @@ Property.prototype.defaults = {
   value: '',
   icon: '',
   functionName: '',
+
+  // If true, the function (if specified) will be applied also for default value
+  applyFunctionOnDefault: false,
   status: '',
   visible: true,
   fixedValues: ['initial', 'inherit'],

--- a/src/style_manager/model/PropertyFactory.js
+++ b/src/style_manager/model/PropertyFactory.js
@@ -179,7 +179,16 @@ export default class PropertyFactory {
       ['box-shadow-spread', {}, 'text-shadow-h'],
       ['transition-duration', { default: '2s', units: this.unitsTime }, 'border-radius-c'],
       ['perspective', {}, 'border-radius-c'],
-      ['transform-rotate-x', { functionName: 'rotateX', units: this.unitsAngle, default: '0', type: typeNumber }],
+      [
+        'transform-rotate-x',
+        {
+          functionName: 'rotateX',
+          units: this.unitsAngle,
+          default: '0',
+          type: typeNumber,
+          applyFunctionOnDefault: true,
+        },
+      ],
       ['transform-rotate-y', { functionName: 'rotateY' }, 'transform-rotate-x'],
       ['transform-rotate-z', { functionName: 'rotateZ' }, 'transform-rotate-x'],
       ['transform-scale-x', { default: '1', functionName: 'scaleX', units: undefined }, 'transform-rotate-x'],


### PR DESCRIPTION
### Issue description
When you apply a transform by using not all parameters, the generated css had a syntax like 
`transform: rotateX(1) 0 0 1 1 1`
which is not correct for browsers.
<img width="506" alt="image" src="https://user-images.githubusercontent.com/40074745/163281803-9dba750c-019c-4be2-a0bf-79cbdc6dd777.png">

Forcing the function interpolation (when needed), the same value is generated as
<img width="848" alt="image" src="https://user-images.githubusercontent.com/40074745/163281990-a3e8492b-988b-42a0-af32-8632bb017558.png">
which is a valid syntax.

### Changelog
Applied the transform function even on default value to get the working css syntax.
Added a new parameter on property to conditionally apply the function