### PR TITLE
Link to English Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,4 +210,4 @@ BSD 3-clause
 
 [Documentation]: <https://grapesjs.com/docs/>
 [API-Reference]: <https://grapesjs.com/docs/api/>
-[CMS]: <https://it.wikipedia.org/wiki/Content_management_system>
+[CMS]: <https://en.wikipedia.org/wiki/Content_management_system>


### PR DESCRIPTION
Given that the README is in English, it makes sense to link to English Wikipedia instead of Italian. At least I found it surprising to be brought to Italian Wikipedia. 🙂 