### PR TITLE
Use coordinates of drag onEnd event for placement in absolute mode. 

### DIFF
--- a/src/utils/Droppable.js
+++ b/src/utils/Droppable.js
@@ -112,8 +112,8 @@ export default class Droppable {
           let comp;
           if (!cancelled) {
             comp = wrapper.append(content)[0];
-            const { left, top, position } = target.getStyle();
-            comp.addStyle({ left, top, position });
+            const { position } = target.getStyle();
+            comp.addStyle({ left: ev.clientX, top: ev.clientY, position });
           }
           this.handleDragEnd(comp, dt);
           target.remove();


### PR DESCRIPTION
Uses clientX/Y from the dragger's onEnd event. Relates to #3770. While it doesn't handle zoom, it should correctly handle a panned canvas. 