### PR TITLE
add option readonly for InputTrait

### DIFF
--- a/src/domain_abstract/ui/Input.js
+++ b/src/domain_abstract/ui/Input.js
@@ -71,8 +71,9 @@ export default class Input extends Backbone.View {
     if (!this.inputEl) {
       const { model, opts } = this;
       const type = opts.type || 'text';
+      const readonly = opts.readonly ? 'readonly' : '';
       const plh = model.get('placeholder') || model.get('defaults') || model.get('default') || '';
-      this.inputEl = $(`<input type="${type}" placeholder="${plh}">`);
+      this.inputEl = $(`<input type="${type}" placeholder="${plh}" ${readonly}>`);
     }
 
     return this.inputEl.get(0);


### PR DESCRIPTION
NumberTrait has built in custom "stepper" mecanism cobined with configurations such as [min, max, step] that works pretty well when used isolated, but the user can insert manually values into the input that not respect this configurations, so with this flag we can force to the user use only the "arrows" controls instead of edit the input manually.

Thanks!