### PR TITLE
Take canvas offsets into account when dropping a new block on the canvas. 

### DIFF
--- a/src/utils/Droppable.js
+++ b/src/utils/Droppable.js
@@ -112,8 +112,13 @@ export default class Droppable {
           let comp;
           if (!cancelled) {
             comp = wrapper.append(content)[0];
-            const { left, top, position } = target.getStyle();
-            comp.addStyle({ left, top, position });
+            const canvasOffset = editor.Canvas.getOffset();
+            const { top, left, position } = target.getStyle();
+            comp.addStyle({
+              left: parseFloat(left) - canvasOffset.left + 'px',
+              top: parseFloat(top) - canvasOffset.top + 'px',
+              position,
+            });
           }
           this.handleDragEnd(comp, dt);
           target.remove();


### PR DESCRIPTION
Relates to #2824 / #3770

I'm not sure this is how you'll want to solve this globally, @artf, but it does seem to fix the dropping of blocks in designer mode on a narrow canvas. I believe there's similar issues with the initial position of the dragged element: Canvas.getMouseRelativeCanvas doesn't correctly take into account the canvas offset but I think the main cause may be CanvasView.getPosition and the way it combines frame offset & canvas offset in a strange way.