### PR TITLE
Add layerManager to EditorConfig interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -250,6 +250,8 @@ declare namespace grapesjs {
 
     /** Keep unused styles within the editor **/
     keepUnusedStyles?: 0;
+
+    layerManager?: LayerManagerConfig;
   }
 
   interface AssetManagerConfig {
@@ -422,6 +424,11 @@ declare namespace grapesjs {
   interface DeviceManagerConfig {
     devices?: Array<object>;
     deviceLabel?: string;
+  }
+
+  interface LayerManagerConfig {
+    appendTo: string;
+    scrollLayers?: number
   }
 
   function init(config: EditorConfig): Editor;


### PR DESCRIPTION
During the "Getting Started" Documentation I found out that layerManager was being identified as an error by typescript