### PR TITLE
fix: [Selector Manager Config] broken link

### DIFF
--- a/docs/modules/Selectors.md
+++ b/docs/modules/Selectors.md
@@ -29,7 +29,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Selector Manager Config](https://github.com/artf/grapesjs/blob/master/src/selector_manager/config/config.js)
+Check the full list of available options here: [Selector Manager Config](https://github.com/artf/grapesjs/blob/master/src/selector_manager/config/config.ts)
 
 
 ## Initialization


### PR DESCRIPTION
Selector Manager configuration Object was broken after migrating to typescript