### PR TITLE
Fix: `"TypeError: this.parseStyle is not a function"` when `setStyles` is called internally (bug introduced in GrapesJS v19.5)

### DIFF
--- a/src/domain_abstract/model/StyleableModel.js
+++ b/src/domain_abstract/model/StyleableModel.js
@@ -3,6 +3,8 @@ import { shallowDiff } from '../../utils/mixins';
 import ParserHtml from '../../parser/model/ParserHtml';
 import { Model } from '../../common';
 
+const parserHtml = ParserHtml();
+
 export default class StyleableModel extends Model {
   /**
    * Forward style string to `parseStyle` to be parse to an object
@@ -10,7 +12,7 @@ export default class StyleableModel extends Model {
    * @returns
    */
   parseStyle(str) {
-    return ParserHtml().parseStyle(str);
+    return parserHtml.parseStyle(str);
   }
 
   /**

--- a/src/domain_abstract/model/StyleableModel.js
+++ b/src/domain_abstract/model/StyleableModel.js
@@ -4,7 +4,14 @@ import ParserHtml from '../../parser/model/ParserHtml';
 import { Model } from '../../common';
 
 export default class StyleableModel extends Model {
-  parseStyle = ParserHtml().parseStyle;
+  /**
+   * Forward style string to `parseStyle` to be parse to an object
+   * @param  {string} str
+   * @returns
+   */
+  parseStyle(str) {
+    return ParserHtml().parseStyle(str);
+  }
 
   /**
    * To trigger the style change event on models I have to

--- a/test/specs/dom_components/model/Component.js
+++ b/test/specs/dom_components/model/Component.js
@@ -417,6 +417,29 @@ describe('Component', () => {
     };
     newObj.components().each(model => inhereted(model));
   });
+
+  test('setStyle parses styles correctly', () => {
+    const styles = 'padding: 12px;height:auto;';
+    const expectedObj = {
+      padding: '12px',
+      height: 'auto',
+    };
+
+    const c = new Component();
+
+    expect(c.setStyle(styles)).toEqual(expectedObj);
+  });
+
+  test('setStyle should be called successfully when invoked internally', () => {
+    const ExtendedComponent = Component.extend({
+      init() {
+        const styles = 'padding: 12px;height:auto;';
+        this.setStyle(styles);
+      },
+    });
+
+    expect(() => new ExtendedComponent()).not.toThrowError();
+  });
 });
 
 describe('Image Component', () => {


### PR DESCRIPTION
# Problem

When `setStyles` is called from internally or in methods you added (via extension), the following error:
```
TypeError: this.parseStyle is not a function
```
## Steps To Reproduce

### This works :heavy_check_mark:
```js
// styles to parse
const styles = 'padding: 12px;height:auto;';

// this works
const c = new Component();
c.setStyle(styles)
```
### This Fails :x:
```js
const styles = 'padding: 12px;height:auto;';

// Extend init() to call setStyle from within a method in one
// of the prototypes
const ExtendedComponent = Component.extend({
     init() {
         // styles to parse
         const styles = 'padding: 12px;height:auto;';

         this.setStyle(styles);
     },
});

// TypeError: this.parseStyle is not a function
new ExtendedComponent()
```
## Theory: Possible Reason Why This is Happening

### Tldr;
`parseStyle` property (of `StyleableModel`) is "hoisted" beyond where it's actually used, thus when it's called by either a method of  `StyleableModel` or `Dom_Components::Model::Component`, it comes up as `undefined`.

### Detail
```mermaid
graph TD;
 StyleableModel-->Dom_Components::Model::Component-->ExtendedComponent;
```
When the Model class is extended via the `.extend` method, the properties of the parent object aren't kept within the parent but are "hoisted"/ moved to the child object. Therefore, if those properties were required in the parent object (which is now the prototype of the child), they have now become inaccessible.

Currently when the `Dom_Components::Model::Component`  is extended via the `.extend` method, the `parseStyle` property is "hoisted" from `StyleableModel` to the child.
```js
import Component from 'dom_components/model/Component';

const ExtendedComponent = Component.extend({})

const child = new ExtendedComponent()

// returns true
Object.hasOwnProperty.call(child, 'parseStyle')
```
Ideally, it should be be located on the prototype of `Dom_Components::Model::Component`.

This is problematic as `parseStyle` is required by the `setStyle` method of `Dom_Components::Model::Component` and  `StyleableModel` which expects `parseStyle` to exist on itself or one of its prototypes.

I don't know if this is an issue with how *Backbone* does inheritance or a quirk of prototypal inheritance.

In conclusion, `this.parseStyle` will always be `undefined` when its called by any method that exists in objects that
are lower in the prototype chain than the topmost object (where `parseStyle` is actually defined).
If `setStyle` is called further down the prototype chain, it throws the following error: `TypeError: this.parseStyle is not a function`

### Suggested Solution
Wrapping the utility function inside a method solves the problem.
```js
 parseStyle(str) {
    return ParserHtml().parseStyle(str);
 }
```
You can suggest other ways of solving this issue.