### PR TITLE
FIX: page.select/remove function signature in Type Definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -675,23 +675,23 @@ declare namespace grapesjs {
   interface Panel extends Backbone.Model<PanelOptions> { }
 
   interface Button extends Backbone.Model<ButtonOptions> { }
-
+  
   interface ButtonOptions {
     id: string;
-    label: string;
-    tagName: 'span';
-    className: string;
-    command: string | ((editor: Editor, opts?: any) => void);
-    context: string;
-    buttons: any[];
-    attributes: object;
-    options: object;
-    active: boolean;
-    dragDrop: boolean;
-    togglable: boolean;
-    runDefaultCommand: boolean;
-    stopDefaultCommand: boolean;
-    disable: boolean;
+    label?: string;
+    tagName?: 'span';
+    className?: string;
+    command?: string | ((editor: Editor, opts?: any) => void);
+    context?: string;
+    buttons?: any[];
+    attributes?: { [key:string]: string};
+    options?: object;
+    active?: boolean;
+    dragDrop?: boolean;
+    togglable?: boolean;
+    runDefaultCommand?: boolean;
+    stopDefaultCommand?: boolean;
+    disable?: boolean;
   }
 
   interface ComponentView {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5481,7 +5481,7 @@ declare namespace grapesjs {
      * const somePage = pageManager.get('page-id');
      * pageManager.select(somePage);
      */
-    select(): this;
+    select(page: string | Page): this;
     /**
      * Get the selected page
      * @example

--- a/index.d.ts
+++ b/index.d.ts
@@ -5445,7 +5445,7 @@ declare namespace grapesjs {
      * const somePage = pageManager.get('page-id');
      * pageManager.remove(somePage);
      */
-    remove(): any;
+    remove(page: string | Page): any;
     /**
      * Get page by id
      * @example


### PR DESCRIPTION
currently, passing in an argument to PageManager throws an error