### PR TITLE
[FIX] add missing ccid in component ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2196,6 +2196,10 @@ declare namespace grapesjs {
      */
     name?: string;
     /**
+     * A randomized unique id associated with the component prefixed with `i`
+     */
+    ccid?: string
+    /**
      * When `true` the component is removable from the canvas, default: `true`
      * @defaultValue true
      */


### PR DESCRIPTION
Context:
Add missing ts definition `ccid?` for component

https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/Component.js#L192