### PR TITLE
Fix for issue #4743 added a check from config

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -106,7 +106,7 @@ export default class EditorModule implements IBaseModule<EditorConfig> {
     this.config = {
       ...defaults,
       ...config,
-      pStylePrefix: defaults.stylePrefix,
+      pStylePrefix: config.stylePrefix ?? defaults.stylePrefix,
     };
     this.em = new EditorModel(this.config);
     this.$ = opts.$;


### PR DESCRIPTION
This fixes BUG: stylePrefix property not overiding the gjs in most elements with the gjs-class #4743