### PR TITLE
Add missing colorPicker option properties in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,8 @@ declare namespace Backbone {
 
 declare namespace grapesjs {
   type PluginOptions = Record<string, any>;
+  type AnyObject = Record<string, any>;
+
 
   type Plugin<T extends PluginOptions = {}> = (editor: Editor, config: T) => void;
 
@@ -263,6 +265,11 @@ declare namespace grapesjs {
     layerManager?: LayerManagerConfig;
 
     parser?: ParserConfig;
+    /**
+       * Color picker options.
+       */
+    colorPicker?: AnyObject;
+    pStylePrefix?: string;
   }
 
   interface AssetManagerConfig {


### PR DESCRIPTION
ColorPicker options are described in editor config.ts but not in index.d.ts