### PR TITLE
Fix nested text problem with CKEditor by adding disableNestingForTypes config option to parser

### DIFF
--- a/src/parser/model/ParserHtml.ts
+++ b/src/parser/model/ParserHtml.ts
@@ -122,6 +122,7 @@ const ParserHtml = (em?: EditorModel, config: ParserConfig = {}) => {
       const nodes = el.childNodes;
 
       for (var i = 0, len = nodes.length; i < len; i++) {
+        const conf = em?.get('Config') || {};
         const node = nodes[i] as HTMLElement;
         const attrs = node.attributes || [];
         const attrsLen = attrs.length;
@@ -129,6 +130,7 @@ const ParserHtml = (em?: EditorModel, config: ParserConfig = {}) => {
         const nodeChild = node.childNodes.length;
         const ct = this.compTypes;
         let model: ComponentDefinitionDefined = {}; // TODO use component properties
+        const disableNestingForTypes = !isUndefined(conf.disableNestingForTypes) ? conf.disableNestingForTypes : [];
 
         // Start with understanding what kind of component it is
         if (ct) {
@@ -261,6 +263,11 @@ const ParserHtml = (em?: EditorModel, config: ParserConfig = {}) => {
           if (allTxt && foundTextNode) {
             model.type = 'text';
           }
+        }
+
+        if (disableNestingForTypes.indexOf(model.type) >= 0) {
+          delete model.components;
+          model.content = node.innerHTML;
         }
 
         // If tagName is still empty and is not a textnode, do not push it


### PR DESCRIPTION
There are some serious problems with using CKEditor as an alternative RTE for grapesJS.

The default behaviour (that can be observed in the webpage demo) is that nested texts are not only allowed, but adding wrapper spans around texts is the way to format parts. The wrapper elements (nested texts) are then handled as individual components and can be formatted with grapesJS tools.

CKEditor also uses spans and other inline html elements with style attribute for formatting. The problem is that during loading such content, grapesjs parses into text content and recognizes the wrapper elements as nested text components and strips style attributes from them. 

detailed description of the problem can be found in issue #4503 


Default text components are not defined by the model's isComponent method, but rather later in the parseNode method at:
```
// If all children are texts and there is some textnode the parent should
// be text too otherwise I'm unable to edit texnodes
```
Therefore the behaviour cannot be controlled in components' isComponent method.


The proposed solution prevents grapesJS from parsing into selected component types for nested components, and adds the node's innerHTML as content instead. 

The proposed configuration option allows the developer to set which types' contents should be handled encapsulated.