### PR TITLE
Fixed number input value does not persist when using up/down arrows, Issue #6012

### DIFF
--- a/src/domain_abstract/ui/InputNumber.ts
+++ b/src/domain_abstract/ui/InputNumber.ts
@@ -140,7 +140,7 @@ export default class InputNumber extends Input {
   upArrowClick() {
     const { model } = this;
     const step = model.get('step');
-    let value = parseFloat(model.get('value'));
+    let value = parseFloat(this.getInputEl().value);
     this.setValue(this.normalizeValue(value + step));
     this.elementUpdated();
   }
@@ -151,7 +151,7 @@ export default class InputNumber extends Input {
   downArrowClick() {
     const { model } = this;
     const step = model.get('step');
-    const value = parseFloat(model.get('value'));
+    const value = parseFloat(this.getInputEl().value);
     this.setValue(this.normalizeValue(value - step));
     this.elementUpdated();
   }


### PR DESCRIPTION
This PR addresses Issue #6012 where the number input value was not persisting when users used the up/down arrows to adjust the value.