### PR TITLE
add label to ButtonProps type definition

### DIFF
--- a/src/panels/config/config.ts
+++ b/src/panels/config/config.ts
@@ -12,6 +12,7 @@ const prv = 'preview';
 interface ButtonProps {
   id?: string;
   active?: boolean;
+  label?: string;
   togglable?: boolean;
   className?: string;
   command?: string | (() => any);


### PR DESCRIPTION
The field `label` seems to be missing from `ButtonProps` type definition. 
```js
const editor = grapesjs.init({
  panels: {
    defaults: [
      {
        id: 'panel-switcher',
        el: '.panel__switcher',
        buttons: [{
            id: 'show-layers',
            active: true,
            label: 'Layers', // Object literal may only specify known properties, and 'label' does not exist in type 'ButtonProps'. 
            command: 'show-layers',
            togglable: false,
          }]
    }
}
```