### PR TITLE
ci: add doc generation step into ci

### DIFF
--- a/.github/workflows/quailty.yml
+++ b/.github/workflows/quailty.yml
@@ -27,4 +27,5 @@ jobs:
       - run: npm run format:check
       - run: yarn build
       - run: npm run ts:build:check
+      - run: npm run docs:api
       - run: npm test


### PR DESCRIPTION
This dependabot pr: 

* https://github.com/GrapesJS/grapesjs/pull/6071

It breaks the docs, but we did not catch it in CI because we don't build or compile the docs, lets add this doc generation runner into the quality checks so that any errors will bubble up and report feedback. 