### PR TITLE
feat: add findFirstType method to Component

### DIFF
--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -187,7 +187,7 @@ console.log(allImages[0]) // prints the first found component
 
 Returns **[Array][5]\<Component>** 
 
-## getType
+## findFirstType
 
 Find the first inner component by component type.
 If no component is found, it returns `undefined`.
@@ -199,7 +199,7 @@ If no component is found, it returns `undefined`.
 ### Examples
 
 ```javascript
-const image = component.getType('image');
+const image = component.findFirstType('image');
 if (image) console.log(image)
 ```
 

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -187,6 +187,24 @@ console.log(allImages[0]) // prints the first found component
 
 Returns **[Array][5]\<Component>** 
 
+## getType
+
+Find the first inner component by component type.
+If no component is found, it returns `undefined`.
+
+### Parameters
+
+*   `type` **[String][1]** Component type
+
+### Examples
+
+```javascript
+const image = component.getType('image');
+if (image) console.log(image)
+```
+
+Returns **Component** Found component, otherwise `undefined`
+
 ## closest
 
 Find the closest parent component by query string.

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -513,12 +513,12 @@ export default class Component extends StyleableModel<ComponentProperties> {
    * @param {String} type Component type
    * @returns {Component|undefined}
    * @example
-   * const image = component.getType('image');
+   * const image = component.findFirstType('image');
    * if (image) {
    *  console.log(image);
    * }
    */
-  getType(type: string): Component | undefined {
+  findFirstType(type: string): Component | undefined {
     return this.findType(type).at(0);
   }
 

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -508,6 +508,21 @@ export default class Component extends StyleableModel<ComponentProperties> {
   }
 
   /**
+   * Find the first inner component by component type.
+   * If no component is found, it returns `undefined`.
+   * @param {String} type Component type
+   * @returns {Component|undefined}
+   * @example
+   * const image = component.getType('image');
+   * if (image) {
+   *  console.log(image);
+   * }
+   */
+  getType(type: string): Component | undefined {
+    return this.findType(type).at(0);
+  }
+
+  /**
    * Find the closest parent component by query string.
    * **ATTENTION**: this method works only with already rendered component
    * @param  {string} query Query string

--- a/test/specs/dom_components/model/Component.ts
+++ b/test/specs/dom_components/model/Component.ts
@@ -273,29 +273,29 @@ describe('Component', () => {
     expect(result.class).toEqual(undefined);
   });
 
-  test('getType returns first component of specified type', () => {
+  test('findFirstType returns first component of specified type', () => {
     const image1 = new ComponentImage({}, compOpts);
     const text = new ComponentText({}, compOpts);
     const image2 = new ComponentImage({}, compOpts);
 
     obj.append([image1, text, image2]);
 
-    const result = obj.getType('image');
+    const result = obj.findFirstType('image');
     expect(result).toBe(image1);
     expect(result instanceof ComponentImage).toBe(true);
   });
 
-  test('getType returns undefined for non-existent type', () => {
+  test('findFirstType returns undefined for non-existent type', () => {
     const text = new ComponentText({}, compOpts);
 
     obj.append(text);
 
-    const result = obj.getType('image');
+    const result = obj.findFirstType('image');
     expect(result).toBeUndefined();
   });
 
-  test('getType returns undefined for empty component', () => {
-    const result = obj.getType('div');
+  test('findFirstType returns undefined for empty component', () => {
+    const result = obj.findFirstType('div');
     expect(result).toBeUndefined();
   });
 

--- a/test/specs/dom_components/model/Component.ts
+++ b/test/specs/dom_components/model/Component.ts
@@ -273,6 +273,32 @@ describe('Component', () => {
     expect(result.class).toEqual(undefined);
   });
 
+  test('getType returns first component of specified type', () => {
+    const image1 = new ComponentImage({}, compOpts);
+    const text = new ComponentText({}, compOpts);
+    const image2 = new ComponentImage({}, compOpts);
+
+    obj.append([image1, text, image2]);
+
+    const result = obj.getType('image');
+    expect(result).toBe(image1);
+    expect(result instanceof ComponentImage).toBe(true);
+  });
+
+  test('getType returns undefined for non-existent type', () => {
+    const text = new ComponentText({}, compOpts);
+
+    obj.append(text);
+
+    const result = obj.getType('image');
+    expect(result).toBeUndefined();
+  });
+
+  test('getType returns undefined for empty component', () => {
+    const result = obj.getType('div');
+    expect(result).toBeUndefined();
+  });
+
   test('setAttributes', () => {
     obj.setAttributes({
       id: 'test',


### PR DESCRIPTION
## Problem

Currently, the `findType` method in the `Component` class returns an array of components (`Component[]`). This can lead to potential type-safety issues when developers need to access the first element of the result. For example:

```typescript
const tileContent = this.findType('tile-body')[0];
tileContent.someMethod(); // Potential runtime error if tileContent is undefined
```

We've explored several approaches to address this issue:

1. Using optional chaining:
   ```typescript
   const tileContent = this.findType('tile-body')[0];
   tileContent?.someMethod();
   ```
   While this prevents runtime errors, it doesn't fully leverage TypeScript's type system to catch potential issues at compile-time.

2. Using type assertions:
   ```typescript
   const tileContent = this.findType('tile-body')[0] as Component;
   ```
   This approach suppresses TypeScript warnings but doesn't actually solve the underlying issue and can lead to runtime errors.

3. Using `Array.prototype.at()`:
   ```typescript
   const tileContent = this.findType('tile-body').at(0);
   if (tileContent) tileContent.someMethod();
   ```
   This approach is better but still requires explicitly include the .at(0) call, which can be error-prone.

We've also attempted to modify type definitions to make `findType` return `(Component | undefined)[]`, but this led to confusing type information and didn't solve the core issue, or wrap it with lodash's `first` method but 
These workarounds, while functional, don't provide an ideal solution that combines type safety, clarity, and ease of use. We believe a more robust solution is needed to address this issue consistently across our codebase.

## Proposed solution

To address this, we propose adding a new method `findFirstType` to the `Component` class. This method will return either a `Component` instance or `undefined`, making it clearer when a component of the specified type is not found.

The existing `closestType` method already follows this pattern, so adding `findFirstType` will not only improve consistency but also provide a more type-safe and intuitive way to access the first component of a given type.