### PR TITLE
docs: fix the 404 Github Action build badge in README

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,7 +7,7 @@ on:
     branches: [dev]
 
 jobs:
-  quailty:
+  quality:
     runs-on: ubuntu-latest
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [GrapesJS](http://grapesjs.com)
 
-[![Build Status](https://github.com/GrapesJS/grapesjs/actions/workflows/build.yml/badge.svg)](https://github.com/GrapesJS/grapesjs/actions)
+[![Build Status](https://github.com/GrapesJS/grapesjs/actions/workflows/quailty.yml/badge.svg)](https://github.com/GrapesJS/grapesjs/actions)
 [![Chat](https://img.shields.io/badge/chat-discord-7289da.svg)](https://discord.gg/QAbgGXq)
 [![CDNJS](https://img.shields.io/cdnjs/v/grapesjs.svg)](https://cdnjs.com/libraries/grapesjs)
 [![npm](https://img.shields.io/npm/v/grapesjs.svg)](https://www.npmjs.com/package/grapesjs)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [GrapesJS](http://grapesjs.com)
 
-[![Build Status](https://github.com/GrapesJS/grapesjs/actions/workflows/quailty.yml/badge.svg)](https://github.com/GrapesJS/grapesjs/actions)
+[![Build Status](https://github.com/GrapesJS/grapesjs/actions/workflows/quality.yml/badge.svg)](https://github.com/GrapesJS/grapesjs/actions)
 [![Chat](https://img.shields.io/badge/chat-discord-7289da.svg)](https://discord.gg/QAbgGXq)
 [![CDNJS](https://img.shields.io/cdnjs/v/grapesjs.svg)](https://cdnjs.com/libraries/grapesjs)
 [![npm](https://img.shields.io/npm/v/grapesjs.svg)](https://www.npmjs.com/package/grapesjs)


### PR DESCRIPTION
## Problem

The status badge in the README points to a 404 image because the workflow's file name has changed. The badge should be updated to reflect the new file name. This causes a display of an ugly 404 image on my end.

## Proposed changes

I've noted that the workflow's file name has a typo. I've updated it. It shouldn't affect the Actions list as it's based on the `name` field in the workflow file.
The README's badge is updated to reflect the new file name.
