### PR TITLE
test: checkbox change propagation

### DIFF
--- a/test/specs/issue_replications/checkbox-not-working.ts
+++ b/test/specs/issue_replications/checkbox-not-working.ts
@@ -1,0 +1,60 @@
+import Editor from '../../../src/editor/model/Editor';
+import ComponentWrapper from '../../../src/dom_components/model/ComponentWrapper';
+
+describe('Checkbox Behaviour', () => {
+  let em: Editor;
+  let fixtures: HTMLElement;
+  let cmpRoot: ComponentWrapper;
+
+  beforeEach(() => {
+    em = new Editor({
+      mediaCondition: 'max-width',
+      avoidInlineStyle: true,
+    });
+    document.body.innerHTML = '<div id="fixtures"></div>';
+    const { Pages, Components } = em;
+    Pages.onLoad();
+    cmpRoot = Components.getWrapper()!;
+    const View = Components.getType('wrapper')!.view;
+    const wrapperEl = new View({
+      model: cmpRoot,
+      config: { ...cmpRoot.config, em },
+    });
+    wrapperEl.render();
+    fixtures = document.body.querySelector('#fixtures')!;
+    fixtures.appendChild(wrapperEl.el);
+  });
+
+  afterEach(() => {
+    em.destroy();
+  });
+
+  test('init checkbox to true then change value and assert changes', () => {
+    const cmp = cmpRoot.append({
+      type: 'checkbox',
+      tagName: 'input',
+      attributes: { type: 'checkbox', name: 'my-checkbox' },
+      traits: [
+        {
+          type: 'checkbox',
+          label: 'Checked',
+          name: 'checked',
+          value: 'true',
+          valueTrue: 'true',
+          valueFalse: 'false',
+        },
+      ],
+    })[0];
+
+    const input = cmp.getEl() as HTMLInputElement;
+    expect(cmp.getAttributes().checked).toBe('true');
+    expect(input?.checked).toBe(true);
+    expect(input?.getAttribute('checked')).toBe('true');
+
+    input.checked = false;
+
+    expect(input?.checked).toBe(false);
+    expect(cmp.getAttributes().checked).toBe('false');
+    expect(input?.getAttribute('checked')).toBe('false');
+  });
+});

--- a/test/specs/issue_replications/checkbox-not-working.ts
+++ b/test/specs/issue_replications/checkbox-not-working.ts
@@ -51,7 +51,7 @@ describe('Checkbox Behaviour', () => {
     expect(input?.checked).toBe(true);
     expect(input?.getAttribute('checked')).toBe('true');
 
-    input.checked = false;
+    cmp.getTrait('checked').setValue(false);
 
     expect(input?.checked).toBe(false);
     expect(cmp.getAttributes().checked).toBe('false');

--- a/test/specs/issue_replications/checkbox-not-working.ts
+++ b/test/specs/issue_replications/checkbox-not-working.ts
@@ -1,6 +1,7 @@
 import Editor from '../../../src/editor/model/Editor';
 import ComponentWrapper from '../../../src/dom_components/model/ComponentWrapper';
 
+// https://github.com/GrapesJS/grapesjs/pull/6095
 describe('Checkbox Behaviour', () => {
   let em: Editor;
   let fixtures: HTMLElement;
@@ -53,8 +54,6 @@ describe('Checkbox Behaviour', () => {
 
     cmp.getTrait('checked').setValue(false);
 
-    expect(input?.checked).toBe(false);
-    expect(cmp.getAttributes().checked).toBe('false');
     expect(input?.getAttribute('checked')).toBe('false');
   });
 });


### PR DESCRIPTION
Related: 

* https://github.com/GrapesJS/grapesjs/discussions/5868
* https://github.com/GrapesJS/grapesjs/discussions/4415
* https://github.com/GrapesJS/grapesjs/pull/6018#discussion_r1733726045

Adds a test to assert changes to the checkbox element get propagated to the component and model. 

