### PR TITLE
test: ensure model and view and el are synced data sources

### DIFF
--- a/test/specs/data_sources/model/ComponentDataVariable.ts
+++ b/test/specs/data_sources/model/ComponentDataVariable.ts
@@ -54,6 +54,7 @@ describe('ComponentDataVariable', () => {
     })[0];
 
     expect(cmp.getEl()?.innerHTML).toContain('Name1');
+    expect(cmp.getInnerHTML()).toContain('Name1');
   });
 
   test('component updates on data-variable change', () => {
@@ -76,11 +77,13 @@ describe('ComponentDataVariable', () => {
     })[0];
 
     expect(cmp.getEl()?.innerHTML).toContain('Name1');
+    expect(cmp.getInnerHTML()).toContain('Name1');
 
     const ds = dsm.get('ds2');
     ds.getRecord('id1')?.set({ name: 'Name1-UP' });
 
     expect(cmp.getEl()?.innerHTML).toContain('Name1-UP');
+    expect(cmp.getInnerHTML()).toContain('Name1-UP');
   });
 
   test("component uses default value if data source doesn't exist", () => {
@@ -119,9 +122,11 @@ describe('ComponentDataVariable', () => {
     })[0];
 
     expect(cmp.getEl()?.innerHTML).toContain('Name1');
+    expect(cmp.getInnerHTML()).toContain('Name1');
 
     dsm.all.reset();
     expect(cmp.getEl()?.innerHTML).toContain('default');
+    expect(cmp.getInnerHTML()).toContain('default');
   });
 
   test('component updates on data source setRecords', () => {
@@ -144,11 +149,13 @@ describe('ComponentDataVariable', () => {
     })[0];
 
     expect(cmp.getEl()?.innerHTML).toContain('init name');
+    expect(cmp.getInnerHTML()).toContain('init name');
 
     const ds = dsm.get(dataSource.id);
     ds.setRecords([{ id: 'id1', name: 'updated name' }]);
 
     expect(cmp.getEl()?.innerHTML).toContain('updated name');
+    expect(cmp.getInnerHTML()).toContain('updated name');
   });
 
   test('component updates on record removal', () => {
@@ -171,11 +178,13 @@ describe('ComponentDataVariable', () => {
     })[0];
 
     expect(cmp.getEl()?.innerHTML).toContain('Name1');
+    expect(cmp.getInnerHTML()).toContain('Name1');
 
     const ds = dsm.get('ds4');
     ds.removeRecord('id1');
 
     expect(cmp.getEl()?.innerHTML).toContain('default');
+    expect(cmp.getInnerHTML()).toContain('default');
   });
 
   test('component initializes and updates with data-variable for nested object', () => {
@@ -205,11 +214,13 @@ describe('ComponentDataVariable', () => {
     })[0];
 
     expect(cmp.getEl()?.innerHTML).toContain('NestedName1');
+    expect(cmp.getInnerHTML()).toContain('NestedName1');
 
     const ds = dsm.get('dsNestedObject');
     ds.getRecord('id1')?.set({ nestedObject: { name: 'NestedName1-UP' } });
 
     expect(cmp.getEl()?.innerHTML).toContain('NestedName1-UP');
+    expect(cmp.getInnerHTML()).toContain('NestedName1-UP');
   });
 
   test('component initializes and updates with data-variable for nested object inside an array', () => {
@@ -244,6 +255,7 @@ describe('ComponentDataVariable', () => {
     })[0];
 
     expect(cmp.getEl()?.innerHTML).toContain('NestedItemName1');
+    expect(cmp.getInnerHTML()).toContain('NestedItemName1');
 
     const ds = dsm.get('dsNestedArray');
     ds.getRecord('id1')?.set({
@@ -256,6 +268,7 @@ describe('ComponentDataVariable', () => {
     });
 
     expect(cmp.getEl()?.innerHTML).toContain('NestedItemName1-UP');
+    expect(cmp.getInnerHTML()).toContain('NestedItemName1-UP');
   });
 
   test('component initalizes and updates data on datarecord set object', () => {

--- a/test/specs/data_sources/model/TraitDataVariable.ts
+++ b/test/specs/data_sources/model/TraitDataVariable.ts
@@ -314,6 +314,7 @@ describe('TraitDataVariable', () => {
 
       const link = cmp.getEl() as HTMLLinkElement;
       expect(link?.href).toBe('http://localhost/url-to-cat-image');
+      expect(cmp?.getAttributes().href).toBe('url-to-cat-image');
 
       const testDs = dsm.get(inputDataSource.id);
       testDs.getRecord('id1')?.set({ value: 'url-to-dog-image' });

--- a/test/specs/data_sources/transformers.ts
+++ b/test/specs/data_sources/transformers.ts
@@ -67,6 +67,7 @@ describe('DataSource Transformers', () => {
 
     const el = cmp.getEl();
     expect(el?.innerHTML).toContain('I LOVE GRAPES');
+    expect(cmp.getInnerHTML()).toContain('I LOVE GRAPES');
 
     const result = ds.getRecord('id1')?.get('content');
     expect(result).toBe('I LOVE GRAPES');
@@ -114,6 +115,7 @@ describe('DataSource Transformers', () => {
 
     const el = cmp.getEl();
     expect(el?.innerHTML).toContain('I LOVE GRAPES');
+    expect(cmp.getInnerHTML()).toContain('I LOVE GRAPES');
 
     const result = ds.getRecord('id1')?.get('content');
     expect(result).toBe('I LOVE GRAPES');


### PR DESCRIPTION
This PR adds more coverage to data sources to ensure model and view and el are in sync. 

Related Comment: 

* https://github.com/GrapesJS/grapesjs/pull/6018#discussion_r1738230787