### PR TITLE
test: coverage for trait changeProp not set

### DIFF
--- a/test/specs/data_sources/model/TraitDataVariable.ts
+++ b/test/specs/data_sources/model/TraitDataVariable.ts
@@ -357,5 +357,23 @@ describe('TraitDataVariable', () => {
       property = cmp.get('test-change-prop');
       expect(property).toBe('I really love grapes');
     });
+
+    test('should cover when changeProp trait value is not set', () => {
+      const cmp = cmpRoot.append({
+        tagName: 'div',
+        type: 'default',
+        'test-change-prop': 'initial-value',
+        traits: [
+          {
+            name: 'test-change-prop',
+            type: 'text',
+            changeProp: true,
+          },
+        ],
+      })[0];
+
+      let property = cmp.get('test-change-prop');
+      expect(property).toBe('initial-value');
+    });
   });
 });


### PR DESCRIPTION
This PR is to add coverage and to start a discussion around `changeProp` and what should happen if the value is set or not. 

Related Comments: 

* https://github.com/GrapesJS/grapesjs/pull/6018#discussion_r1738190949
* https://github.com/GrapesJS/grapesjs/pull/6018#discussion_r1738234885