### PR TITLE
Fix Sorter usage in StyleManager

### DIFF
--- a/packages/core/src/utils/Sorter.ts
+++ b/packages/core/src/utils/Sorter.ts
@@ -55,7 +55,7 @@ export interface SorterOptions {
   scale?: number;
 }
 
-const noop = () => { };
+const noop = () => {};
 
 const targetSpotType = CanvasSpotBuiltInTypes.Target;
 

--- a/packages/core/src/utils/Sorter.ts
+++ b/packages/core/src/utils/Sorter.ts
@@ -55,7 +55,7 @@ export interface SorterOptions {
   scale?: number;
 }
 
-const noop = () => {};
+const noop = () => { };
 
 const targetSpotType = CanvasSpotBuiltInTypes.Target;
 
@@ -697,7 +697,14 @@ export default class Sorter extends View {
       return result;
     }
 
-    const index = pos ? (pos.method === 'after' ? pos.indexEl + 1 : pos.indexEl) : trgModel.components().length;
+    let length = -1;
+    const isCollection = trgModel instanceof Collection;
+    if (isFunction(trgModel.components)) {
+      length = trgModel.components().length;
+    } else if (isCollection) {
+      length = trgModel.models.length;
+    }
+    const index = pos ? (pos.method === 'after' ? pos.indexEl + 1 : pos.indexEl) : length;
 
     // Check if the source is draggable in target
     let draggable = srcModel.get('draggable');


### PR DESCRIPTION
For #6122 
**Merging this PR is for a temporary fix for the bug as we will refactor the Sorter soon** 

- The model in the style manager doesn't have the `.components()` method. Instead, we should check if it's a collection and get the length from there.