### PR TITLE
refactor: remove extra build

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -25,5 +25,5 @@ runs:
       run: pnpm install
       shell: bash
     - name: Build project
-      run: pnpm build --force
+      run: pnpm build
       shell: bash

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,8 +15,6 @@ jobs:
         run: pnpm lint
       - name: Format Check
         run: pnpm format:check
-      - name: Build
-        run: pnpm build --force
       - name: Test
         run: pnpm test
       - name: Docs


### PR DESCRIPTION
We have an extra build step in the CI we don't need, and --force is not needed either. 