### PR TITLE
Add ability to drag multiple selected components

### DIFF
--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -139,7 +139,7 @@ export default class CommandsModule extends Module<CommandsConfig & { pStylePref
         const em = ed.getModel();
         const { event } = opts;
         const trg = opts.target as Component | undefined;
-        const trgs = trg ? [trg] : [...ed.getSelectedAll()];
+        const trgs = Array.isArray(trg) ? trg : trg ? [trg] : [...ed.getSelectedAll()];
         const targets = trgs.map((trg) => trg.delegate?.move?.(trg) || trg).filter(Boolean);
         const target = targets[targets.length - 1] as Component | undefined;
         const nativeDrag = event?.type === 'dragstart';

--- a/packages/core/src/dom_components/view/ComponentView.ts
+++ b/packages/core/src/dom_components/view/ComponentView.ts
@@ -164,7 +164,7 @@ TComp> {
     event.stopPropagation();
     event.preventDefault();
     this.em.Commands.run('tlb-move', {
-      target: [...this.em.getEditor().getSelectedAll()],
+      target: [...this.em.getSelectedAll()],
       event,
     });
   }

--- a/packages/core/src/dom_components/view/ComponentView.ts
+++ b/packages/core/src/dom_components/view/ComponentView.ts
@@ -164,7 +164,7 @@ TComp> {
     event.stopPropagation();
     event.preventDefault();
     this.em.Commands.run('tlb-move', {
-      target: this.model,
+      target: [...this.em.getEditor().getSelectedAll()],
       event,
     });
   }
@@ -559,7 +559,7 @@ TComp> {
     this.updateClasses();
   }
 
-  onAttrUpdate() {}
+  onAttrUpdate() { }
 
   render() {
     this.renderAttributes();

--- a/packages/core/src/dom_components/view/ComponentView.ts
+++ b/packages/core/src/dom_components/view/ComponentView.ts
@@ -559,7 +559,7 @@ TComp> {
     this.updateClasses();
   }
 
-  onAttrUpdate() { }
+  onAttrUpdate() {}
 
   render() {
     this.renderAttributes();


### PR DESCRIPTION
When dragging multiple selected components on the canvas, only one component is currently moved. However, dragging from the drag icon in the toolbar correctly moves all selected components.