### PR TITLE
Fix CLI installation and add Windows compatibility for scripts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "BUILD_MODE=production webpack --config ./webpack.cli.ts",
+    "postinstall": "pnpm run build",
+    "build": "cross-env BUILD_MODE=production webpack --config ./webpack.cli.ts",
     "build:watch": "webpack --config ./webpack.cli.ts --watch",
     "lint": "eslint src",
     "patch": "npm version patch -m 'Bump v%s'",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,6 @@
     "dist"
   ],
   "scripts": {
-    "postinstall": "pnpm run build",
     "build": "cross-env BUILD_MODE=production webpack --config ./webpack.cli.ts",
     "build:watch": "webpack --config ./webpack.cli.ts --watch",
     "lint": "eslint src",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "build": "npm run build-all",
     "build-all": "run-s build:*",
     "build:js": "node node_modules/grapesjs-cli/dist/cli.js build --patch=false --targets=\"> 1%, ie 11, safari 8, not dead\" --statsOutput=\"stats.json\" --localePath=\"src/i18n/locale\"",
-    "build:mjs": "BUILD_MODULE=true node node_modules/grapesjs-cli/dist/cli.js build --dts='skip' --patch=false --targets=\"> 1%, ie 11, safari 8, not dead\"",
+    "build:mjs": "cross-env BUILD_MODULE=true node node_modules/grapesjs-cli/dist/cli.js build --dts='skip' --patch=false --targets=\"> 1%, ie 11, safari 8, not dead\"",
     "build:css": "sass src/styles/scss/main.scss dist/css/grapes.min.css --no-source-map --style=compressed --load-path=node_modules",
     "ts:build": "node node_modules/grapesjs-cli/dist/cli.js build --dts='only' --patch=false",
     "ts:check": "tsc --noEmit --esModuleInterop dist/index.d.ts",


### PR DESCRIPTION
To use the GrapesJS framework via the CLI, we must first build the CLI itself. Therefore, we should add a build step for the CLI after the installation process.
```json
"start:js": "node node_modules/grapesjs-cli/dist/cli.js serve"
```

I also added cross-env before some script so that they will work on Windows machines.