### PR TITLE
Fix moving selected component after dragging an unselected component

### DIFF
--- a/packages/core/src/dom_components/view/ComponentView.ts
+++ b/packages/core/src/dom_components/view/ComponentView.ts
@@ -163,8 +163,10 @@ TComp> {
     if (!this.__isDraggable()) return false;
     event.stopPropagation();
     event.preventDefault();
+    const selected = this.em.getSelectedAll();
+    const modelsToMove = selected.includes(this.model) ? selected : [this.model];
     this.em.Commands.run('tlb-move', {
-      target: [...this.em.getSelectedAll()],
+      target: modelsToMove,
       event,
     });
   }


### PR DESCRIPTION
#6155 implemented the ability to move multiple components after dragging. However, we should ensure that the dragged component is selected before attempting to move the selected components or else move the dragged component only.