### PR TITLE
feat: expose DataVariableListenerManager & DataVariable

### DIFF
--- a/packages/core/src/data_sources/index.ts
+++ b/packages/core/src/data_sources/index.ts
@@ -42,6 +42,8 @@ import { get, stringToPath } from '../utils/mixins';
 import DataRecord from './model/DataRecord';
 import DataSource from './model/DataSource';
 import DataSources from './model/DataSources';
+import DataVariableListenerManager, { DataVariableListenerManagerOptions } from './model/DataVariableListenerManager';
+import DataVariable from './model/DataVariable';
 import { DataSourcesEvents, DataSourceProps } from './types';
 import { Events } from 'backbone';
 
@@ -177,5 +179,13 @@ export default class DataSourceManager extends ItemManagerModule<ModuleConfig, D
    */
   load(data: any) {
     return this.loadProjectData(data);
+  }
+
+  newDataVariableListenerManager(options: Omit<DataVariableListenerManagerOptions, 'em'>) {
+    return new DataVariableListenerManager({ ...options, em: this.em });
+  }
+
+  newDataVariable(options: any) {
+    return new DataVariable(options, { em: this.em });
   }
 }


### PR DESCRIPTION
For upstream usage of DataVariables. It is needed to manage listeners outside of the scope of the core. 