### PR TITLE
Fix sorter performance

### DIFF
--- a/packages/core/src/commands/view/SelectPosition.ts
+++ b/packages/core/src/commands/view/SelectPosition.ts
@@ -36,13 +36,6 @@ export default {
       });
 
     if (opts.onStart) this.sorter.eventHandlers.legacyOnStartSort = opts.onStart;
-    this.em.on(
-      'frame:scroll',
-      ((...agrs: any[]) => {
-        const canvasScroll = this.canvas.getCanvasView().frame === agrs[0].frame;
-        if (canvasScroll) this.sorter.recalculateTargetOnScroll();
-      }).bind(this),
-    );
     sourceElements &&
       sourceElements.length > 0 &&
       this.sorter.startSort(sourceElements.map((element) => ({ element })));

--- a/packages/core/src/commands/view/SelectPosition.ts
+++ b/packages/core/src/commands/view/SelectPosition.ts
@@ -13,7 +13,7 @@ export default {
     const utils = this.em.Utils;
     const container = sourceElements[0].ownerDocument.body;
 
-    if (utils && !this.sorter)
+    if (utils)
       this.sorter = new utils.ComponentSorter({
         em: this.em,
         treeClass: CanvasComponentNode,

--- a/packages/core/src/utils/Droppable.ts
+++ b/packages/core/src/utils/Droppable.ts
@@ -187,13 +187,6 @@ export default class Droppable {
         sorter.eventHandlers.legacyOnEnd = sorterOptions.legacyOnEnd;
         sorter.containerContext.customTarget = sorterOptions.customTarget;
       }
-      this.em.on(
-        'frame:scroll',
-        ((...agrs: any[]) => {
-          const canvasScroll = this.canvas.getCanvasView().frame === agrs[0].frame;
-          if (canvasScroll) sorter.recalculateTargetOnScroll();
-        }).bind(this),
-      );
       let dropModel = this.getTempDropModel(content);
       const el = dropModel.view?.el;
       const sources = el ? [{ element: el, dragSource: dragSourceOrigin }] : [];

--- a/packages/core/src/utils/sorter/BaseComponentNode.ts
+++ b/packages/core/src/utils/sorter/BaseComponentNode.ts
@@ -53,14 +53,6 @@ export abstract class BaseComponentNode extends SortableTreeNode<Component> {
   }
 
   /**
-   * Invalidate the cache for a specific child when necessary, such as when the display state might have changed.
-   * @param {Component} child - The child component whose cache to invalidate.
-   */
-  invalidateDisplayCache(child: Component): void {
-    this.displayCache.delete(child);
-  }
-
-  /**
    * Get the parent component of this node.
    * @returns {BaseComponentNode | null} - The parent wrapped in BaseComponentNode,
    * or null if no parent exists.
@@ -197,7 +189,7 @@ export abstract class BaseComponentNode extends SortableTreeNode<Component> {
 
   /**
    * Disable editing capabilities for the component's view.
-   * This method depends on the presence of the disableEditing method in the view.
+   * This method depends on the presence of the `disableEditing` method in the view.
    */
   private disableEditing(): void {
     // @ts-ignore

--- a/packages/core/src/utils/sorter/BaseComponentNode.ts
+++ b/packages/core/src/utils/sorter/BaseComponentNode.ts
@@ -8,6 +8,8 @@ import { SortableTreeNode } from './SortableTreeNode';
  * Subclasses must implement the `view` and `element` methods.
  */
 export abstract class BaseComponentNode extends SortableTreeNode<Component> {
+  private displayCache: Map<Component, boolean> = new Map();
+
   /**
    * Get the list of child components.
    * @returns {BaseComponentNode[] | null} - The list of children wrapped in
@@ -19,18 +21,43 @@ export abstract class BaseComponentNode extends SortableTreeNode<Component> {
 
   /**
    * Get the list of displayed children, i.e., components that have a valid HTML element.
+   * Cached values are used to avoid recalculating the display status unnecessarily.
    * @returns {BaseComponentNode[] | null} - The list of displayed children wrapped in
    * BaseComponentNode, or null if there are no displayed children.
    */
   private getDisplayedChildren(): BaseComponentNode[] | null {
     const children = this.model.components();
-    const displayedChildren = children.filter((child) => {
-      const element = child.getEl();
-
-      return isDisplayed(element);
-    });
+    const displayedChildren = children.filter((child) => this.isChildDisplayed(child));
 
     return displayedChildren.map((comp: Component) => new (this.constructor as any)(comp));
+  }
+
+  /**
+   * Check if a child is displayed, using cached value if available.
+   * @param {Component} child - The child component to check.
+   * @returns {boolean} - Whether the child is displayed.
+   */
+  private isChildDisplayed(child: Component): boolean {
+    // Check if display status is cached
+    if (this.displayCache.has(child)) {
+      return this.displayCache.get(child)!;
+    }
+
+    const element = child.getEl();
+    const displayed = isDisplayed(element);
+
+    // Cache the display status
+    this.displayCache.set(child, displayed);
+
+    return displayed;
+  }
+
+  /**
+   * Invalidate the cache for a specific child when necessary, such as when the display state might have changed.
+   * @param {Component} child - The child component whose cache to invalidate.
+   */
+  invalidateDisplayCache(child: Component): void {
+    this.displayCache.delete(child);
   }
 
   /**
@@ -170,7 +197,7 @@ export abstract class BaseComponentNode extends SortableTreeNode<Component> {
 
   /**
    * Disable editing capabilities for the component's view.
-   * This method depends on the presence of the `disableEditing` method in the view.
+   * This method depends on the presence of the disableEditing method in the view.
    */
   private disableEditing(): void {
     // @ts-ignore
@@ -208,8 +235,13 @@ export abstract class BaseComponentNode extends SortableTreeNode<Component> {
   }
 }
 
-function isDisplayed(element: HTMLElement | undefined) {
-  if (!!!element) return false;
+/**
+ * Function to check if an element is displayed in the DOM.
+ * @param {HTMLElement | undefined} element - The element to check.
+ * @returns {boolean} - Whether the element is displayed.
+ */
+function isDisplayed(element: HTMLElement | undefined): boolean {
+  if (!element) return false;
   return (
     element instanceof HTMLElement &&
     window.getComputedStyle(element).display !== 'none' &&

--- a/packages/core/src/utils/sorter/BaseComponentNode.ts
+++ b/packages/core/src/utils/sorter/BaseComponentNode.ts
@@ -133,8 +133,7 @@ export abstract class BaseComponentNode extends SortableTreeNode<Component> {
 
     for (let i = 0; i < children.length; i++) {
       const child = children.at(i);
-      const element = child.getEl();
-      const displayed = isDisplayed(element);
+      const displayed = this.isChildDisplayed(child);
 
       if (displayed) displayedCount++;
       if (displayedCount === index + 1) return i;

--- a/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
+++ b/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
@@ -29,10 +29,8 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
       return this._cachedShallowModels.get(contentItem)!;
     }
 
-    let srcModel;
-
     const wrapper = this.model.em.Components.getShallowWrapper();
-    srcModel = wrapper?.append(contentItem)[0];
+    const srcModel = wrapper?.append(contentItem)[0];
 
     if (srcModel) {
       this._cachedShallowModels.set(contentItem, srcModel);

--- a/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
+++ b/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
@@ -61,7 +61,6 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
   }
 
   private canMoveSingleContent(contentItem: ContentElement | Component, index: number): boolean {
-    // console.log("🚀 ~ CanvasNewComponentNode ~ canMoveSingleContent ~ contentItem:", contentItem)
     return this.model.em.Components.canMove(this.model, contentItem, index).result;
   }
 

--- a/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
+++ b/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
@@ -78,7 +78,6 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
 
   /**
    * Adds a single content item to the current node.
-   * The source node will first ensure that the model for the content is cached.
    * @param {ContentType} content - The content to add.
    * @param {number} index - The index where the content is to be added.
    * @param {boolean} insertingTextableIntoText - Whether the operation involves textable content.
@@ -90,7 +89,6 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
     insertingTextableIntoText: boolean,
   ): CanvasNewComponentNode {
     let model;
-
     if (insertingTextableIntoText) {
       // @ts-ignore
       model = this.model?.getView?.()?.insertComponent?.(content, { action: 'add-component' });

--- a/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
+++ b/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
@@ -31,6 +31,9 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
 
     const wrapper = this.model.em.Components.getShallowWrapper();
     const srcModel = wrapper?.append(contentItem)[0];
+    // Replace getEl as the element would be removed in the shallow wrapper after 100ms
+    const el = srcModel?.getEl();
+    srcModel!.getEl = () => el;
 
     if (srcModel) {
       this._cachedShallowModels.set(contentItem, srcModel);
@@ -58,6 +61,7 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
   }
 
   private canMoveSingleContent(contentItem: ContentElement | Component, index: number): boolean {
+    // console.log("🚀 ~ CanvasNewComponentNode ~ canMoveSingleContent ~ contentItem:", contentItem)
     return this.model.em.Components.canMove(this.model, contentItem, index).result;
   }
 

--- a/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
+++ b/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
@@ -20,24 +20,20 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
    * @param contentItem - The content item to retrieve or cache.
    * @returns {Component | null} - The shallow wrapper model, either cached or retrieved.
    */
-  cacheSrcModelForContent(contentItem: ContentElement): Component | null {
-    // Check if the contentItem is already cached in the source node
+  cacheSrcModelForContent(contentItem: ContentElement | Component): Component | undefined {
+    if (isComponent(contentItem)) {
+      return contentItem;
+    }
+
     if (this._cachedShallowModels.has(contentItem)) {
       return this._cachedShallowModels.get(contentItem)!;
     }
 
-    let srcModel: Component | null = null;
+    let srcModel;
 
-    // If contentItem is already a component, directly cache it
-    if (isComponent(contentItem)) {
-      srcModel = contentItem;
-    } else {
-      // Fetch the shallow model from the wrapper
-      const wrapper = this.model.em.Components.getShallowWrapper();
-      srcModel = wrapper?.append(contentItem)[0] || null;
-    }
+    const wrapper = this.model.em.Components.getShallowWrapper();
+    srcModel = wrapper?.append(contentItem)[0];
 
-    // Cache the shallow model for future reference
     if (srcModel) {
       this._cachedShallowModels.set(contentItem, srcModel);
     }
@@ -45,12 +41,6 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
     return srcModel;
   }
 
-  /**
-   * Moves the content from the source node at a specified index.
-   * @param {CanvasNewComponentNode} source - The source node.
-   * @param {number} index - The index where the content is to be moved.
-   * @returns {boolean} Whether the move is allowed.
-   */
   canMove(source: CanvasNewComponentNode, index: number): boolean {
     const realIndex = this.getRealIndex(index);
     const { model: symbolModel, content, dragDef } = source._dragSource;
@@ -61,14 +51,12 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
     if (Array.isArray(sourceContent)) {
       return (
         sourceContent.every((contentItem, i) =>
-          // @ts-ignore
-          this.canMoveSingleContent(source.cacheSrcModelForContent(contentItem), realIndex + i),
+          this.canMoveSingleContent(source.cacheSrcModelForContent(contentItem)!, realIndex + i),
         ) && canMoveSymbol
       );
     }
 
-    // @ts-ignore
-    return this.canMoveSingleContent(source.cacheSrcModelForContent(sourceContent), realIndex) && canMoveSymbol;
+    return this.canMoveSingleContent(source.cacheSrcModelForContent(sourceContent)!, realIndex) && canMoveSymbol;
   }
 
   private canMoveSingleContent(contentItem: ContentElement | Component, index: number): boolean {

--- a/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
+++ b/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
@@ -60,8 +60,8 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
 
     if (Array.isArray(sourceContent)) {
       return (
-        // @ts-ignore
         sourceContent.every((contentItem, i) =>
+          // @ts-ignore
           this.canMoveSingleContent(source.cacheSrcModelForContent(contentItem), realIndex + i),
         ) && canMoveSymbol
       );

--- a/packages/core/src/utils/sorter/ComponentSorter.ts
+++ b/packages/core/src/utils/sorter/ComponentSorter.ts
@@ -1,3 +1,4 @@
+import { bindAll } from 'underscore';
 import { CanvasSpotBuiltInTypes } from '../../canvas/model/CanvasSpot';
 import Component from '../../dom_components/model/Component';
 import EditorModel from '../../editor/model/Editor';
@@ -62,11 +63,29 @@ export default class ComponentSorter<NodeType extends BaseComponentNode> extends
         },
       },
     });
+
+    bindAll(this, 'handleScrollEvent');
   }
 
   private onStartSort() {
     this.em.clearSelection();
     this.setAutoCanvasScroll(true);
+  }
+
+  protected bindDragEventHandlers() {
+    this.em.on('frame:scroll', this.handleScrollEvent);
+    super.bindDragEventHandlers();
+  }
+
+  protected cleanupEventListeners(): void {
+    this.em.off('frame:scroll', this.handleScrollEvent);
+    super.cleanupEventListeners();
+  }
+
+  handleScrollEvent(...agrs: any[]) {
+    const frame = agrs?.[0]?.frame;
+    const canvasScroll = this.em.Canvas.getCanvasView().frame === frame;
+    if (canvasScroll) this.recalculateTargetOnScroll();
   }
 
   private onMouseMove = (mouseEvent: MouseEvent) => {

--- a/packages/core/src/utils/sorter/Dimension.ts
+++ b/packages/core/src/utils/sorter/Dimension.ts
@@ -1,0 +1,67 @@
+import CanvasModule from '../../canvas';
+
+/**
+ * A class representing dimensions of an element, including position, size, offsets, and other metadata.
+ * Provides functionality to calculate differences between current and previous dimensions and update them.
+ */
+export default class Dimension {
+  public top: number;
+  public left: number;
+  public height: number;
+  public width: number;
+  public offsets: ReturnType<CanvasModule['getElementOffsets']>;
+  public dir?: boolean;
+  public el?: HTMLElement;
+  public indexEl?: number;
+
+  /**
+   * Initializes the DimensionCalculator with the given initial dimensions.
+   *
+   * @param initialDimensions - The initial dimensions containing `top`, `left`, `height`, `width`, and other properties.
+   */
+  constructor(initialDimensions: {
+    top: number;
+    left: number;
+    height: number;
+    width: number;
+    offsets: ReturnType<CanvasModule['getElementOffsets']>;
+    dir?: boolean;
+    el?: HTMLElement;
+    indexEl?: number;
+  }) {
+    this.top = initialDimensions.top;
+    this.left = initialDimensions.left;
+    this.height = initialDimensions.height;
+    this.width = initialDimensions.width;
+    this.offsets = initialDimensions.offsets;
+    this.dir = initialDimensions.dir;
+    this.el = initialDimensions.el;
+    this.indexEl = initialDimensions.indexEl;
+  }
+
+  /**
+   * Calculates the difference between the current and previous dimensions.
+   * If there are no previous dimensions, it will return zero differences.
+   *
+   * @returns An object containing the differences in `top` and `left` positions.
+   */
+  public calculateDimensionDifference(dimension: Dimension): { topDifference: number; leftDifference: number } {
+    const topDifference = dimension.top - this.top;
+    const leftDifference = dimension.left - this.left;
+
+    return { topDifference, leftDifference };
+  }
+
+  /**
+   * Updates the current dimensions by adding the given differences to the `top` and `left` values.
+   *
+   * @param topDifference - The difference to add to the current `top` value.
+   * @param leftDifference - The difference to add to the current `left` value.
+   */
+  public adjustDimensions(difference: { topDifference: number; leftDifference: number }): Dimension {
+    this.top += difference.topDifference;
+    this.left += difference.leftDifference;
+
+    return this;
+  }
+}

--- a/packages/core/src/utils/sorter/Dimension.ts
+++ b/packages/core/src/utils/sorter/Dimension.ts
@@ -12,8 +12,6 @@ export default class Dimension {
   public width: number;
   public offsets: ReturnType<CanvasModule['getElementOffsets']>;
   public dir?: boolean;
-  public el?: HTMLElement;
-  public indexEl?: number;
 
   /**
    * Initializes the DimensionCalculator with the given initial dimensions.
@@ -36,8 +34,6 @@ export default class Dimension {
     this.width = initialDimensions.width;
     this.offsets = initialDimensions.offsets;
     this.dir = initialDimensions.dir;
-    this.el = initialDimensions.el;
-    this.indexEl = initialDimensions.indexEl;
   }
 
   /**
@@ -82,5 +78,39 @@ export default class Dimension {
     } else {
       return mouseX < xCenter ? 'before' : 'after';
     }
+  }
+
+  /**
+   * Compares the current dimension object with another dimension to check equality.
+   *
+   * @param {Dimension} dimension - The dimension to compare against.
+   * @returns {boolean} True if the dimensions are equal, otherwise false.
+   */
+  public equals(dimension: Dimension | undefined): boolean {
+    if (!dimension) return false;
+    return (
+      this.top === dimension.top &&
+      this.left === dimension.left &&
+      this.height === dimension.height &&
+      this.width === dimension.width &&
+      this.dir === dimension.dir &&
+      JSON.stringify(this.offsets) === JSON.stringify(dimension.offsets)
+    );
+  }
+
+  /**
+   * Creates a clone of the current Dimension object.
+   *
+   * @returns {Dimension} A new Dimension object with the same properties.
+   */
+  public clone(): Dimension {
+    return new Dimension({
+      top: this.top,
+      left: this.left,
+      height: this.height,
+      width: this.width,
+      offsets: { ...this.offsets }, // Shallow copy of offsets
+      dir: this.dir,
+    });
   }
 }

--- a/packages/core/src/utils/sorter/Dimension.ts
+++ b/packages/core/src/utils/sorter/Dimension.ts
@@ -1,4 +1,5 @@
 import CanvasModule from '../../canvas';
+import { Placement } from './types';
 
 /**
  * A class representing dimensions of an element, including position, size, offsets, and other metadata.
@@ -63,5 +64,23 @@ export default class Dimension {
     this.left += difference.leftDifference;
 
     return this;
+  }
+
+  /**
+   * Determines the placement ('before' or 'after') based on the X and Y coordinates and center points.
+   *
+   * @param {number} mouseX X coordinate of the mouse
+   * @param {number} mouseY Y coordinate of the mouse
+   * @return {Placement} 'before' or 'after'
+   */
+  public determinePlacement(mouseX: number, mouseY: number): Placement {
+    const xCenter = this.left + this.width / 2;
+    const yCenter = this.top + this.height / 2;
+
+    if (this.dir) {
+      return mouseY < yCenter ? 'before' : 'after';
+    } else {
+      return mouseX < xCenter ? 'before' : 'after';
+    }
   }
 }

--- a/packages/core/src/utils/sorter/DropLocationDeterminer.ts
+++ b/packages/core/src/utils/sorter/DropLocationDeterminer.ts
@@ -136,7 +136,8 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
     const moveData: MoveData<NodeType> = this.getMoveData(targetNode, mouseX, mouseY);
 
     const placeHolderPositionChanged = moveData.placeholderDimensions !== this.lastMoveData.placeholderDimensions;
-    if (placeHolderPositionChanged) {
+    const placeHolderPlacmentChanged = moveData.placement !== this.lastMoveData.placement;
+    if (placeHolderPositionChanged || placeHolderPlacmentChanged) {
       this.eventHandlers.onPlaceholderPositionChange?.(moveData.placeholderDimensions!, moveData.placement!);
     }
 

--- a/packages/core/src/utils/sorter/DropLocationDeterminer.ts
+++ b/packages/core/src/utils/sorter/DropLocationDeterminer.ts
@@ -271,9 +271,11 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
    */
   private getOrCreateHoveredNode(hoveredModel: T): NodeType {
     const lastHoveredNode = this.lastMoveData.hoveredNode;
-    const newHoveredNode = new this.treeClass(hoveredModel);
+    const hoveredNode = new this.treeClass(hoveredModel);
+    const newHoveredNode = hoveredNode.equals(lastHoveredNode) ? lastHoveredNode : hoveredNode;
+    this.lastMoveData.hoveredNode = newHoveredNode;
 
-    return newHoveredNode.equals(lastHoveredNode) ? lastHoveredNode : newHoveredNode;
+    return newHoveredNode;
   }
 
   /**

--- a/packages/core/src/utils/sorter/PlaceholderClass.ts
+++ b/packages/core/src/utils/sorter/PlaceholderClass.ts
@@ -1,6 +1,11 @@
 import { View } from '../../common';
 import { Dimension, Placement } from './types';
 
+type PlaceHolderPosition = {
+  elementDimension: Dimension;
+  placement: Placement;
+};
+
 export class PlaceholderClass extends View {
   pfx: string;
   allowNesting: boolean;
@@ -10,6 +15,10 @@ export class PlaceholderClass extends View {
     top: number;
     left: number;
   };
+  private moveThreshold: number = 100; // Threshold in milliseconds
+  private lastMoveTimeout: NodeJS.Timeout | null = null; // Store the last timeout
+  private latestPosition?: PlaceHolderPosition;
+
   constructor(options: {
     container: HTMLElement;
     pfx?: string;
@@ -40,11 +49,30 @@ export class PlaceholderClass extends View {
   }
 
   /**
-   * Updates the position of the placeholder.
+   * Updates the position of the placeholder with a movement threshold.
    * @param {Dimension} elementDimension element dimensions.
-   * @param {Position} placement either before or after the target.
+   * @param {Placement} placement either before or after the target.
    */
   move(elementDimension: Dimension, placement: Placement) {
+    console.log('🚀 ~ PlaceholderClass ~ move ~ move:');
+    this.latestPosition = {
+      elementDimension,
+      placement,
+    };
+
+    if (this.lastMoveTimeout === null) {
+      // Set a new timeout to update the styles after the threshold period
+      this.lastMoveTimeout = setTimeout(() => {
+        if (this.latestPosition) {
+          const { elementDimension, placement } = this.latestPosition;
+          this._move(elementDimension, placement);
+        }
+        this.lastMoveTimeout = null;
+      }, this.moveThreshold);
+    }
+  }
+
+  private _move(elementDimension: Dimension, placement: string) {
     const marginOffset = 0;
     const unit = 'px';
     let top = 0;

--- a/packages/core/src/utils/sorter/RateLimiter.ts
+++ b/packages/core/src/utils/sorter/RateLimiter.ts
@@ -1,0 +1,31 @@
+export class RateLimiter<T> {
+    private threshold: number;
+    private lastArgs: T | undefined;
+    private timeout: NodeJS.Timeout | null = null;
+
+    constructor(threshold: number) {
+        this.threshold = threshold;
+    }
+
+    updateArgs(args: T) {
+        this.lastArgs = args;
+    }
+
+    execute(callback: (args: T) => void) {
+        if (!this.timeout) {
+            this.timeout = setTimeout(() => {
+                if (this.lastArgs) {
+                    callback(this.lastArgs);
+                }
+                this.timeout = null;
+            }, this.threshold);
+        }
+    }
+
+    clearTimeout() {
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+        }
+    }
+}

--- a/packages/core/src/utils/sorter/RateLimiter.ts
+++ b/packages/core/src/utils/sorter/RateLimiter.ts
@@ -1,31 +1,31 @@
 export class RateLimiter<T> {
-    private threshold: number;
-    private lastArgs: T | undefined;
-    private timeout: NodeJS.Timeout | null = null;
+  private threshold: number;
+  private lastArgs: T | undefined;
+  private timeout: NodeJS.Timeout | null = null;
 
-    constructor(threshold: number) {
-        this.threshold = threshold;
-    }
+  constructor(threshold: number) {
+    this.threshold = threshold;
+  }
 
-    updateArgs(args: T) {
-        this.lastArgs = args;
-    }
+  updateArgs(args: T) {
+    this.lastArgs = args;
+  }
 
-    execute(callback: (args: T) => void) {
-        if (!this.timeout) {
-            this.timeout = setTimeout(() => {
-                if (this.lastArgs) {
-                    callback(this.lastArgs);
-                }
-                this.timeout = null;
-            }, this.threshold);
+  execute(callback: (args: T) => void) {
+    if (!this.timeout) {
+      this.timeout = setTimeout(() => {
+        if (this.lastArgs) {
+          callback(this.lastArgs);
         }
+        this.timeout = null;
+      }, this.threshold);
     }
+  }
 
-    clearTimeout() {
-        if (this.timeout) {
-            clearTimeout(this.timeout);
-            this.timeout = null;
-        }
+  clearTimeout() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
     }
+  }
 }

--- a/packages/core/src/utils/sorter/SortableTreeNode.ts
+++ b/packages/core/src/utils/sorter/SortableTreeNode.ts
@@ -1,4 +1,5 @@
 import { View } from '../../common';
+import Dimension from './Dimension';
 import { DragSource } from './types';
 
 /**
@@ -9,6 +10,10 @@ import { DragSource } from './types';
 export abstract class SortableTreeNode<T> {
   protected _model: T;
   protected _dragSource: DragSource<T>;
+  /** The dimensions of the node. */
+  public nodeDimensions?: Dimension;
+  /** The dimensions of the child elements within the target node. */
+  public childrenDimensions?: Dimension[];
   constructor(model: T, dragSource: DragSource<T> = {}) {
     this._model = model;
     this._dragSource = dragSource;
@@ -87,7 +92,12 @@ export abstract class SortableTreeNode<T> {
     return this._dragSource;
   }
 
-  equals(node?: SortableTreeNode<T>): boolean {
+  equals(node?: SortableTreeNode<T>): node is SortableTreeNode<T> {
     return !!node?._model && this._model === node._model;
+  }
+
+  adjustDimensions(difference: { topDifference: number; leftDifference: number }) {
+    this.nodeDimensions?.adjustDimensions(difference);
+    this.childrenDimensions?.forEach((dims) => dims.adjustDimensions(difference));
   }
 }

--- a/packages/core/src/utils/sorter/SortableTreeNode.ts
+++ b/packages/core/src/utils/sorter/SortableTreeNode.ts
@@ -96,8 +96,10 @@ export abstract class SortableTreeNode<T> {
     return !!node?._model && this._model === node._model;
   }
 
-  adjustDimensions(difference: { topDifference: number; leftDifference: number }) {
-    this.nodeDimensions?.adjustDimensions(difference);
-    this.childrenDimensions?.forEach((dims) => dims.adjustDimensions(difference));
+  adjustDimensions(diff: { topDifference: number; leftDifference: number }) {
+    if (diff.topDifference === 0 && diff.leftDifference === 0) return;
+
+    this.nodeDimensions?.adjustDimensions(diff);
+    this.childrenDimensions?.forEach((dims) => dims.adjustDimensions(diff));
   }
 }

--- a/packages/core/src/utils/sorter/Sorter.ts
+++ b/packages/core/src/utils/sorter/Sorter.ts
@@ -107,7 +107,7 @@ export default class Sorter<T, NodeType extends SortableTreeNode<T>> {
   /**
    * This method is should be called when the user scrolls within the container.
    */
-  recalculateTargetOnScroll(): void {
+  protected recalculateTargetOnScroll(): void {
     this.dropLocationDeterminer.recalculateTargetOnScroll();
   }
 
@@ -183,7 +183,7 @@ export default class Sorter<T, NodeType extends SortableTreeNode<T>> {
     return sourceElement;
   }
 
-  private bindDragEventHandlers() {
+  protected bindDragEventHandlers() {
     on(this.containerContext.document, 'keydown', this.rollback);
   }
 
@@ -196,7 +196,7 @@ export default class Sorter<T, NodeType extends SortableTreeNode<T>> {
    *
    * @private
    */
-  private cleanupEventListeners(): void {
+  protected cleanupEventListeners(): void {
     off(this.containerContext.document, 'keydown', this.rollback);
   }
 

--- a/packages/core/src/utils/sorter/Sorter.ts
+++ b/packages/core/src/utils/sorter/Sorter.ts
@@ -12,9 +12,9 @@ import {
   PositionOptions,
   SorterDragBehaviorOptions,
   SorterEventHandlers,
-  Dimension,
   Placement,
 } from './types';
+import Dimension from './Dimension';
 import { SorterOptions } from './types';
 
 export default class Sorter<T, NodeType extends SortableTreeNode<T>> {

--- a/packages/core/src/utils/sorter/SorterUtils.ts
+++ b/packages/core/src/utils/sorter/SorterUtils.ts
@@ -134,18 +134,6 @@ export function closest(el: HTMLElement, selector: string): HTMLElement | undefi
     elem = elem.parentNode;
   }
 }
-/**
- * Determines if an element is in the normal flow of the document.
- * This checks whether the element is not floated or positioned in a way that removes it from the flow.
- *
- * @param  {HTMLElement} el - The element to check.
- * @param  {HTMLElement} [parent=document.body] - The parent element for additional checks (defaults to `document.body`).
- * @return {boolean} Returns `true` if the element is in flow, otherwise `false`.
- * @private
- */
-export function isInFlow(el: HTMLElement, parent: HTMLElement = document.body): boolean {
-  return !!el && isStyleInFlow(el, parent);
-}
 
 /**
  * Checks if an element has styles that keep it in the document flow.
@@ -156,7 +144,7 @@ export function isInFlow(el: HTMLElement, parent: HTMLElement = document.body): 
  * @return {boolean} Returns `true` if the element is styled to be in flow, otherwise `false`.
  * @private
  */
-function isStyleInFlow(el: HTMLElement, parent: HTMLElement): boolean {
+export function isStyleInFlow(el: HTMLElement, parent: HTMLElement): boolean {
   if (isTextNode(el)) return false;
 
   const elementStyles = el.style || {};

--- a/packages/core/src/utils/sorter/SorterUtils.ts
+++ b/packages/core/src/utils/sorter/SorterUtils.ts
@@ -3,7 +3,8 @@ import EditorModel from '../../editor/model/Editor';
 import { isTextNode } from '../dom';
 import { matches as matchesMixin } from '../mixins';
 import { SortableTreeNode } from './SortableTreeNode';
-import { Dimension, Placement, DragDirection, SorterOptions } from './types';
+import { Placement, DragDirection, SorterOptions } from './types';
+import Dimension from './Dimension';
 
 /**
  * Find the position based on passed dimensions and coordinates

--- a/packages/core/src/utils/sorter/types.ts
+++ b/packages/core/src/utils/sorter/types.ts
@@ -1,6 +1,6 @@
-import CanvasModule from '../../canvas';
 import { ComponentDefinition } from '../../dom_components/model/types';
 import EditorModel from '../../editor/model/Editor';
+import Dimension from './Dimension';
 import { SortableTreeNode } from './SortableTreeNode';
 
 export type ContentElement = string | ComponentDefinition;
@@ -23,17 +23,6 @@ export interface DraggableContent {
 export type DragSource<T> = DraggableContent & {
   model?: T;
 };
-
-export interface Dimension {
-  top: number;
-  left: number;
-  height: number;
-  width: number;
-  offsets: ReturnType<CanvasModule['getElementOffsets']>;
-  dir?: boolean;
-  el?: HTMLElement;
-  indexEl?: number;
-}
 
 export type Placement = 'inside' | 'before' | 'after';
 


### PR DESCRIPTION
**Changes**

Most changes are focused on performance enhancement. The following operations were expensive:

* Repositioning the placeholder
* Recomputing the drop position
* Dragging from the blocks (adding the block to the shallow wrapper each time was costly)
* Checking if a given component is displayed or not
* Calling `canMove` every time the mouse moved
* On canvas scroll handler was not being cleared

**Improvements**

* **Repositioning the placeholder:** Now happens every 50 milliseconds.
* **Recomputing drop position:** Now happens every 20 milliseconds. Both calculations are 100% accurate for determining the final drop position.
* **Shallow wrapper models:** Cached for the entire dragging process.
* **Component display check:** Now cached as well.
* **`canMove`:** Called only when the user changes the index or target.
* Move the canvas scroll handler to the component sorter and clear it after sorting
* Improvements to bubbling from the mouse target to the first valid target.

These changes should improve the overall performance.
