### PR TITLE
CssRule view datavar event propagation

### DIFF
--- a/packages/core/src/css_composer/index.ts
+++ b/packages/core/src/css_composer/index.ts
@@ -111,8 +111,7 @@ export default class CssComposer extends ItemManagerModule<CssComposerConfig & {
    * @private
    */
   postLoad() {
-    const um = this.em?.get('UndoManager');
-    um && um.add(this.getAll());
+    this.em.UndoManager.add(this.getAll());
   }
 
   store() {

--- a/packages/core/src/css_composer/model/CssRule.ts
+++ b/packages/core/src/css_composer/model/CssRule.ts
@@ -94,7 +94,7 @@ export default class CssRule extends StyleableModel<CssRuleProperties> {
   config: CssRuleProperties;
   em?: EditorModel;
   opt: any;
-  view?: CssRuleView;
+  views: CssRuleView[] = [];
   dataVariableListeners: Record<string, DataVariableListenerManager> = {};
 
   defaults() {
@@ -121,7 +121,7 @@ export default class CssRule extends StyleableModel<CssRuleProperties> {
     this.em = opt.em;
     this.ensureSelectors(null, null, {});
     this.on('change', this.__onChange);
-    super.setStyle(this.get('style'));
+    this.setStyle(this.get('style'));
   }
 
   __onChange(m: CssRule, opts: any) {
@@ -364,13 +364,5 @@ export default class CssRule extends StyleableModel<CssRuleProperties> {
     }
 
     return true;
-  }
-
-  setView(cssRuleView: CssRuleView) {
-    super.setView(cssRuleView);
-  }
-
-  getView() {
-    return this.view;
   }
 }

--- a/packages/core/src/css_composer/model/CssRule.ts
+++ b/packages/core/src/css_composer/model/CssRule.ts
@@ -1,5 +1,5 @@
 import { isEmpty, forEach, isString, isArray } from 'underscore';
-import { Model, ObjectAny } from '../../common';
+import { Model, ObjectAny, View } from '../../common';
 import StyleableModel from '../../domain_abstract/model/StyleableModel';
 import Selectors from '../../selector_manager/model/Selectors';
 import { getMediaLength } from '../../code_manager/model/CssGenerator';

--- a/packages/core/src/css_composer/model/CssRule.ts
+++ b/packages/core/src/css_composer/model/CssRule.ts
@@ -6,6 +6,8 @@ import { getMediaLength } from '../../code_manager/model/CssGenerator';
 import { isEmptyObj, hasWin } from '../../utils/mixins';
 import Selector, { SelectorProps } from '../../selector_manager/model/Selector';
 import EditorModel from '../../editor/model/Editor';
+import CssRuleView from '../view/CssRuleView';
+import DataVariableListenerManager from '../../data_sources/model/DataVariableListenerManager';
 
 /** @private */
 export interface CssRuleProperties {
@@ -92,6 +94,8 @@ export default class CssRule extends StyleableModel<CssRuleProperties> {
   config: CssRuleProperties;
   em?: EditorModel;
   opt: any;
+  view?: CssRuleView;
+  dataVariableListeners: Record<string, DataVariableListenerManager> = {};
 
   defaults() {
     return {
@@ -117,6 +121,7 @@ export default class CssRule extends StyleableModel<CssRuleProperties> {
     this.em = opt.em;
     this.ensureSelectors(null, null, {});
     this.on('change', this.__onChange);
+    super.setStyle(this.get('style'));
   }
 
   __onChange(m: CssRule, opts: any) {
@@ -359,5 +364,13 @@ export default class CssRule extends StyleableModel<CssRuleProperties> {
     }
 
     return true;
+  }
+
+  setView(cssRuleView: CssRuleView) {
+    super.setView(cssRuleView);
+  }
+
+  getView() {
+    return this.view;
   }
 }

--- a/packages/core/src/css_composer/view/CssRuleView.ts
+++ b/packages/core/src/css_composer/view/CssRuleView.ts
@@ -13,7 +13,7 @@ export default class CssRuleView extends View<CssRule> {
     this.listenTo(model.get('selectors'), 'change', this.render);
   }
 
-  // @ts-ignore
+  /** @ts-ignore */
   tagName() {
     return 'style';
   }

--- a/packages/core/src/css_composer/view/CssRuleView.ts
+++ b/packages/core/src/css_composer/view/CssRuleView.ts
@@ -21,6 +21,7 @@ export default class CssRuleView extends View<CssRule> {
 
   remove() {
     super.remove();
+    this.model.removeView(this);
     return this;
   }
 

--- a/packages/core/src/css_composer/view/CssRuleView.ts
+++ b/packages/core/src/css_composer/view/CssRuleView.ts
@@ -1,3 +1,4 @@
+import FrameView from '../../canvas/view/FrameView';
 import { View } from '../../common';
 import CssRule from '../model/CssRule';
 
@@ -11,6 +12,20 @@ export default class CssRuleView extends View<CssRule> {
     this.listenTo(model, 'change', this.render);
     this.listenTo(model, 'destroy remove', this.remove);
     this.listenTo(model.get('selectors'), 'change', this.render);
+    model.setView(this);
+  }
+
+  get frameView(): FrameView {
+    return this.config.frameView;
+  }
+
+  remove() {
+    super.remove();
+    return this;
+  }
+
+  updateStyles() {
+    this.render();
   }
 
   /** @ts-ignore */

--- a/packages/core/src/css_composer/view/CssRulesView.ts
+++ b/packages/core/src/css_composer/view/CssRulesView.ts
@@ -82,6 +82,8 @@ export default class CssRulesView extends View {
       rendered = view.render().el;
     }
 
+    model.setView(view);
+
     const clsName = this.className!;
     const mediaText = model.get('mediaText');
     const defaultBlockId = getBlockId(clsName);

--- a/packages/core/src/css_composer/view/CssRulesView.ts
+++ b/packages/core/src/css_composer/view/CssRulesView.ts
@@ -82,8 +82,6 @@ export default class CssRulesView extends View {
       rendered = view.render().el;
     }
 
-    model.setView(view);
-
     const clsName = this.className!;
     const mediaText = model.get('mediaText');
     const defaultBlockId = getBlockId(clsName);

--- a/packages/core/src/dom_components/view/ComponentView.ts
+++ b/packages/core/src/dom_components/view/ComponentView.ts
@@ -304,6 +304,10 @@ TComp> {
     }
   }
 
+  updateStyles() {
+    this.updateStyle();
+  }
+
   /**
    * Update classe attribute
    * @private

--- a/packages/core/src/domain_abstract/model/StyleableModel.ts
+++ b/packages/core/src/domain_abstract/model/StyleableModel.ts
@@ -175,9 +175,12 @@ export default class StyleableModel<T extends ObjectHash = any> extends Model<T>
 
   setView(view: StyleableView) {
     let { views } = this;
-    if (!views.includes(view)) {
-      views.push(view);
-    }
+    !views.includes(view) && views.push(view);
+  }
+
+  removeView(view: StyleableView) {
+    const { views } = this;
+    views.splice(views.indexOf(view), 1);
   }
 
   updateView() {

--- a/packages/core/src/domain_abstract/model/StyleableModel.ts
+++ b/packages/core/src/domain_abstract/model/StyleableModel.ts
@@ -7,6 +7,7 @@ import EditorModel from '../../editor/model/Editor';
 import StyleDataVariable from '../../data_sources/model/StyleDataVariable';
 import { DataVariableType } from '../../data_sources/model/DataVariable';
 import DataVariableListenerManager from '../../data_sources/model/DataVariableListenerManager';
+import CssRuleView from '../../css_composer/view/CssRuleView';
 
 export type StyleProps = Record<
   string,
@@ -35,6 +36,12 @@ export const getLastStyleValue = (value: string | string[]) => {
 export default class StyleableModel<T extends ObjectHash = any> extends Model<T> {
   em?: EditorModel;
   dataVariableListeners: Record<string, DataVariableListenerManager> = {};
+  view?: CssRuleView;
+
+  constructor(attributes: T, options: { em?: EditorModel } = {}) {
+    super(attributes, options);
+    this.em = options.em;
+  }
 
   /**
    * Parse style string to an object
@@ -153,6 +160,17 @@ export default class StyleableModel<T extends ObjectHash = any> extends Model<T>
     style[prop] = value;
     this.setStyle(style, { noEvent: true });
     this.trigger(`change:style:${prop}`);
+    this.updateView();
+  }
+
+  setView(view: CssRuleView) {
+    this.view = view;
+  }
+
+  updateView() {
+    if (this.view) {
+      this.view.render();
+    }
   }
 
   /**

--- a/packages/core/src/domain_abstract/model/StyleableModel.ts
+++ b/packages/core/src/domain_abstract/model/StyleableModel.ts
@@ -1,5 +1,5 @@
 import { isArray, isString, keys } from 'underscore';
-import { Model, ObjectAny, ObjectHash, SetOptions } from '../../common';
+import { Model, ObjectAny, ObjectHash, SetOptions, View } from '../../common';
 import ParserHtml from '../../parser/model/ParserHtml';
 import Selectors from '../../selector_manager/model/Selectors';
 import { shallowDiff } from '../../utils/mixins';
@@ -8,6 +8,7 @@ import StyleDataVariable from '../../data_sources/model/StyleDataVariable';
 import { DataVariableType } from '../../data_sources/model/DataVariable';
 import DataVariableListenerManager from '../../data_sources/model/DataVariableListenerManager';
 import CssRuleView from '../../css_composer/view/CssRuleView';
+import ComponentView from '../../dom_components/view/ComponentView';
 
 export type StyleProps = Record<
   string,
@@ -36,7 +37,7 @@ export const getLastStyleValue = (value: string | string[]) => {
 export default class StyleableModel<T extends ObjectHash = any> extends Model<T> {
   em?: EditorModel;
   dataVariableListeners: Record<string, DataVariableListenerManager> = {};
-  view?: CssRuleView;
+  view?: ComponentView | CssRuleView;
 
   constructor(attributes: T, options: { em?: EditorModel } = {}) {
     super(attributes, options);
@@ -163,7 +164,7 @@ export default class StyleableModel<T extends ObjectHash = any> extends Model<T>
     this.updateView();
   }
 
-  setView(view: CssRuleView) {
+  setView(view: ComponentView | CssRuleView) {
     this.view = view;
   }
 

--- a/packages/core/test/specs/data_sources/model/StyleDataVariable.ts
+++ b/packages/core/test/specs/data_sources/model/StyleDataVariable.ts
@@ -183,7 +183,7 @@ describe('StyleDataVariable', () => {
         content: 'Hello World',
       })[0];
 
-      em.getEditor().CssComposer.addCollection([
+      const [rule] = em.getEditor().CssComposer.addCollection([
         {
           selectors: [],
           selectorsAdd: selector,
@@ -198,11 +198,13 @@ describe('StyleDataVariable', () => {
         },
       ]);
 
+      expect(rule.getStyle()).toHaveProperty('color', 'red');
       expect(em.getEditor().getCss()).toContain(`${selector}{color:red;}`);
 
       const ds = dsm.get(dsId);
       ds.getRecord(drId)?.set({ value: 'blue' });
 
+      expect(rule.getStyle()).toHaveProperty('color', 'blue');
       expect(em.getEditor().getCss()).toContain(`${selector}{color:blue;}`);
     });
   });

--- a/packages/core/test/specs/data_sources/model/StyleDataVariable.ts
+++ b/packages/core/test/specs/data_sources/model/StyleDataVariable.ts
@@ -183,7 +183,9 @@ describe('StyleDataVariable', () => {
         content: 'Hello World',
       })[0];
 
-      const [rule] = em.getEditor().CssComposer.addCollection([
+      const cssComposer = em.getEditor().CssComposer;
+
+      const [rule] = cssComposer.addCollection([
         {
           selectors: [],
           selectorsAdd: selector,
@@ -198,14 +200,19 @@ describe('StyleDataVariable', () => {
         },
       ]);
 
+      cssComposer.render();
+      const view = rule.getView();
+
       expect(rule.getStyle()).toHaveProperty('color', 'red');
       expect(em.getEditor().getCss()).toContain(`${selector}{color:red;}`);
+      expect(view?.el.innerHTML).toContain(`h1{color:red;}`);
 
       const ds = dsm.get(dsId);
       ds.getRecord(drId)?.set({ value: 'blue' });
 
       expect(rule.getStyle()).toHaveProperty('color', 'blue');
       expect(em.getEditor().getCss()).toContain(`${selector}{color:blue;}`);
+      expect(view?.el.innerHTML).toContain(`h1{color:blue;}`);
     });
   });
 });


### PR DESCRIPTION
This PR stores the view on a CSS rule and correctly attaches data variable listeners to update the model **and view** on change. 