### PR TITLE
ci: slient pass the GITHUB_TOKEN before push

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -43,6 +43,9 @@ jobs:
           # stage all and commit
           git add -A
           git commit -m 'deploy docs'
+
+          # Pass the GITHUB_TOKEN before push: https://stackoverflow.com/a/69979203
+          git config --unset-all http.https://github.com/.extraheader
           git push https://x-access-token:${GITHUB_TOKEN}@github.com/GrapesJS/website.git main
 
           cd -


### PR DESCRIPTION
This will silent pass thru the token so we can push to the other repo.

https://stackoverflow.com/questions/64374179/how-to-push-to-another-repository-in-github-actions/69979203#69979203

Related: 
* https://github.com/GrapesJS/grapesjs/pull/6251
* https://github.com/GrapesJS/grapesjs/pull/6240