### PR TITLE
ci: docs push use GRAPESJS_BOT_TOKEN

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,11 +17,11 @@ jobs:
       - uses: ./.github/actions/setup-project
       - name: Setup Git
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.name 'GrapesJSBot'
+          git config --global user.email 'services@grapesjs.com'
       - name: Build and Deploy Docs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GRAPESJS_BOT_TOKEN: ${{ secrets.GRAPESJS_BOT_TOKEN }}
         working-directory: ./docs
         run: |
           # abort on errors
@@ -47,8 +47,7 @@ jobs:
           git add -A
           git commit -m 'deploy docs'
 
-          # Pass the GITHUB_TOKEN before push: https://stackoverflow.com/a/69979203
-          git config --unset-all http.https://github.com/.extraheader
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/GrapesJS/website.git main
+          # Push using PAT
+          git push https://$GRAPESJS_BOT_TOKEN@github.com/GrapesJS/website.git main
 
           cd -


### PR DESCRIPTION
Using our new bot for pushing to the docs repo: 

https://github.com/GrapesJSBot