### PR TITLE
Throw an error if trying to access a data variable with undefined em

### DIFF
--- a/packages/core/src/data_sources/model/DataVariable.ts
+++ b/packages/core/src/data_sources/model/DataVariable.ts
@@ -5,7 +5,7 @@ import { stringToPath } from '../../utils/mixins';
 export const DataVariableType = 'data-variable';
 
 export default class DataVariable extends Model {
-  em: EditorModel;
+  em?: EditorModel;
 
   defaults() {
     return {
@@ -40,7 +40,7 @@ export default class DataVariable extends Model {
     if (!this.em) {
       throw new Error('EditorModel instance is not provided for a data variable.');
     }
-    const val = this.em.DataSources.getValue(path, defaultValue);
+    const val = this.em?.DataSources.getValue(path, defaultValue);
 
     return val;
   }

--- a/packages/core/src/data_sources/model/DataVariable.ts
+++ b/packages/core/src/data_sources/model/DataVariable.ts
@@ -5,7 +5,7 @@ import { stringToPath } from '../../utils/mixins';
 export const DataVariableType = 'data-variable';
 
 export default class DataVariable extends Model {
-  em?: EditorModel;
+  em: EditorModel;
 
   defaults() {
     return {
@@ -37,7 +37,10 @@ export default class DataVariable extends Model {
 
   getDataValue() {
     const { path, defaultValue } = this.attributes;
-    const val = this.em?.DataSources.getValue(path, defaultValue);
+    if (!this.em) {
+      throw new Error('EditorModel instance is not provided for a data variable.');
+    }
+    const val = this.em.DataSources.getValue(path, defaultValue);
 
     return val;
   }


### PR DESCRIPTION
Currently if `em` is `undefined` in a data variable. the value is undefined, I think for a better error handling, we should throw an error instead.