### PR TITLE
Fix layer manager drag and drop

### DIFF
--- a/packages/core/src/utils/sorter/LayersComponentNode.ts
+++ b/packages/core/src/utils/sorter/LayersComponentNode.ts
@@ -1,6 +1,11 @@
 import { BaseComponentNode } from './BaseComponentNode';
 
 export default class LayersComponentNode extends BaseComponentNode {
+  protected _dropAreaConfig = {
+    ratio: 0.5,
+    minUndroppableDimension: 3, // In px
+    maxUndroppableDimension: 15, // In px
+  };
   /**
    * Get the associated view of this component.
    * @returns The view associated with the component, or undefined if none.

--- a/packages/core/src/utils/sorter/LayersComponentNode.ts
+++ b/packages/core/src/utils/sorter/LayersComponentNode.ts
@@ -2,9 +2,9 @@ import { BaseComponentNode } from './BaseComponentNode';
 
 export default class LayersComponentNode extends BaseComponentNode {
   protected _dropAreaConfig = {
-    ratio: 0.5,
+    ratio: 0.4,
     minUndroppableDimension: 3, // In px
-    maxUndroppableDimension: 15, // In px
+    maxUndroppableDimension: 20, // In px
   };
   /**
    * Get the associated view of this component.


### PR DESCRIPTION
For https://github.com/GrapesJS/grapesjs/issues/6281

We need more area to allow dragging in-between components in the layer manager
![image](https://github.com/user-attachments/assets/fb75a738-5880-4e42-9591-02b26d4ae0a1)
