### PR TITLE
fix: ensure the pointer-init class is removed when updating the "locked" state

### DIFF
--- a/packages/core/src/dom_components/view/ComponentView.ts
+++ b/packages/core/src/dom_components/view/ComponentView.ts
@@ -241,7 +241,7 @@ TComp> {
     const hoveredCls = `${ppfx}hovered`;
     const noPointerCls = `${ppfx}no-pointer`;
     const pointerInitCls = `${ppfx}pointer-init`;
-    const toRemove = [selectedCls, selectedParentCls, freezedCls, hoveredCls, noPointerCls];
+    const toRemove = [selectedCls, selectedParentCls, freezedCls, hoveredCls, noPointerCls, pointerInitCls];
     const selCls = extHl && !opts.noExtHl ? '' : selectedCls;
     this.$el.removeClass(toRemove.join(' '));
     const actualCls = el.getAttribute('class') || '';

--- a/packages/core/test/specs/dom_components/view/ComponentView.ts
+++ b/packages/core/test/specs/dom_components/view/ComponentView.ts
@@ -143,4 +143,20 @@ describe('ComponentView', () => {
     const result = model.getAttributes();
     expect(result.class).toEqual(undefined);
   });
+
+  test('updateStatus removes previous classes and adds new ones', () => {
+    model.addClass('selected');
+
+    model.set('locked', true);
+    view.updateStatus();
+    expect(view.el.getAttribute('class')).toEqual('no-pointer');
+
+    model.set('locked', false);
+    view.updateStatus();
+    expect(view.el.getAttribute('class')).toEqual('pointer-init');
+
+    model.set('locked');
+    view.updateStatus();
+    expect(view.el.getAttribute('class')).toEqual('');
+  });
 });


### PR DESCRIPTION
The locking mechanism does not work as expected when unlocking an element.  
This is due to the fact that both `pointer-init` and `no-pointer` classes are present on the element.  
When unlocking and then locking the element, we expect the element to remain locked.  

This PR ensures that `pointer-init` is removed along with the other classes to avoid conflict.
 
 
 Reproduction in https://app.grapesjs.com/
![2024-11-18 at 10 49 22 - Tan Lark](https://github.com/user-attachments/assets/c0e6a01f-7d50-4dcd-910f-ee6c62131f07)
