### PR TITLE
fix: unknown pseudo element and unused rulesets in scss

### DIFF
--- a/packages/core/src/styles/scss/main.scss
+++ b/packages/core/src/styles/scss/main.scss
@@ -104,14 +104,8 @@ $colorsAll: (one, var(--gjs-primary-color)), (two, var(--gjs-secondary-color)), 
 }
 
 .#{$app-prefix}test {
-  &::btn {
+  &btn {
     color: '#fff';
-  }
-
-  &input {
-  }
-
-  &header {
   }
 }
 .opac50 {


### PR DESCRIPTION
I am trying to compile grapesjs using turbopack, which can't seem to parse the minified css of grapesjs:

```
'btn' is not recognized as a valid pseudo-element. Did you mean ':btn' (pseudo-class) or is this a typo? at [project]/node_modules/grapesjs/dist/css/grapes.min.css:0:20688
```

So I just fixed it directly in the main scss file. Though I am not sure what was wanted for the `btn` class. I also removed unused ruleset.