### PR TITLE
fix: Add height CSS for Safari not showing layer icons (#6394)

### DIFF
--- a/packages/core/src/styles/scss/_gjs_layers.scss
+++ b/packages/core/src/styles/scss/_gjs_layers.scss
@@ -148,6 +148,7 @@ $layerIconSize: 15px !default;
     &-move {
       display: flex;
       width: 13px;
+      height: 13px;
       box-sizing: content-box;
       cursor: move;
     }

--- a/packages/core/src/styles/scss/_gjs_layers.scss
+++ b/packages/core/src/styles/scss/_gjs_layers.scss
@@ -51,6 +51,7 @@ $layerIconSize: 15px !default;
       &-off {
         display: flex;
         width: 13px;
+        height: 13px;
       }
 
       &-off {
@@ -69,6 +70,7 @@ $layerIconSize: 15px !default;
 
     &-caret {
       width: 15px;
+      height: 15px;
       cursor: pointer;
       box-sizing: content-box;
       transform: rotate(90deg);


### PR DESCRIPTION
Confirmed that layer icons were not showing up in Safari (v18.3). Safari was not matching the set width that was already defined like Chrome and Firefox were. The easiest thing to do here is to just set the height at the same size as the width for the icons - it fixes Safari and doesn't change the computer sizes in the other browsers.

There probably isn't any point in a unit test for this as we wouldn't easily be able to test in a specific browser anyways.

As a side note, I say a deprecation warning for the use of `@import` statements in Sass:

```
Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
2 │ @import 'codemirror/lib/codemirror';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    src/styles/scss/main.scss 2:9  root stylesheet
```

I'll take a look to see how difficult it would be to fix that.

Closes #6394.