### PR TITLE
Add ECMAScript locale modules

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -52,9 +52,14 @@ export const buildLocale = async (opts: BuildOptions = {}) => {
   const babelOpts = { ...babelConfig(buildWebpackArgs(opts) as any) };
   fs.readdirSync(localDst).forEach((file) => {
     const filePath = `${localDst}/${file}`;
+    const esModuleFileName = filePath.replace(/\.[^.]+$/, '.mjs');
+    fs.copyFileSync(filePath, esModuleFileName);
     const compiled = transformFileSync(filePath, babelOpts).code;
     fs.writeFileSync(filePath, compiled);
   });
+
+  // Remove the index.mjs as it is useless
+  fs.unlinkSync(`${localDst}/index.mjs`);
 
   printRow('Locale files building completed successfully!');
 };


### PR DESCRIPTION
Implements a possible workaround for #2721 

What's happening during the build is that first the source locale files are copied over from `packages/core/src/locale` to `packages/core/locale` and then pushed through webpack for transpilation and the original files are overridden. 

For use cases where an ECMAScript module is required (e.g. when importing files using the `<script type="importmap">`) it is imperative that the files are not transpiled. For that reason, before the transpilation, the original content is copied over to `<filename>.mjs` thus making a copy of the file in ECMAScript module format, which those files are originally in.
