### PR TITLE
Performance Improvement (NewComponent Drag)

### DIFF
--- a/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
+++ b/packages/core/src/utils/sorter/CanvasNewComponentNode.ts
@@ -13,7 +13,7 @@ export default class CanvasNewComponentNode extends CanvasComponentNode {
     const { model: symbolModel, content, dragDef } = source._dragSource;
 
     const canMoveSymbol = !symbolModel || !this.isSourceSameSymbol(symbolModel);
-    const sourceContent: CanMoveSource = (isFunction(content) ? dragDef : content) || source.model;
+    const sourceContent: CanMoveSource = source.model;
 
     if (Array.isArray(sourceContent)) {
       return (


### PR DESCRIPTION
## Optimize `canMove` Performance for New Components

**Problem:**
When dragging new component blocks from the blocks panel onto the GrapesJS canvas, there can be significant UI lag, especially with more complex component definitions or frequent drag operations.

**Root Cause:**
The performance issue stems from how the `source` argument is handled in `ComponentManager.prototype.canMove` (or its equivalent).
When a new component is dragged, the `CanvasNewComponentNode.prototype.canMove` method determines what representation of the new component (`sourceContent`) is passed to `ComponentManager.prototype.canMove`.
The original logic in `CanvasNewComponentNode.prototype.canMove` could result in `sourceContent` being a simplified plain JavaScript object (e.g., `{ type: 'our-custom-block-component_v1' }`) derived from the block's definition, rather than the fully instantiated GrapesJS component model that `CanvasNewComponentNode` already wraps (`this.model`).

> Caveat: The main reason for the simplification of the sourceModel line is due to the fact that the build of our custom blocks requires us to add elements that cause the left-side of the || to return truthy, which makes the assignment of source.model never happen. If that wasn't a requirement, then this wouldn't need to be fixed.

When `ComponentManager.prototype.canMove` receives this simplified object, it doesn't recognize it as a full component model. Consequently, it falls back to an expensive operation: `wrapper.append(source, { temporary: true })`. This on-the-fly creation of a temporary component instance for validation purposes is a primary cause of the observed drag lag.

**Solution:**
This PR modifies `CanvasNewComponentNode.prototype.canMove` to ensure that the `sourceContent` passed for validation is always the fully instantiated GrapesJS component model (`this.model`) that the `CanvasNewComponentNode` instance wraps.

**Conceptual Change in `CanvasNewComponentNode.prototype.canMove`:**

```diff
--- /utils/sorter/CanvasNewComponentNode.js
+++ /utils/sorter/CanvasNewComponentNode.js
@@ -XX,XX +XX,XX @@
   canMove(source: CanvasNewComponentNode, index: number): boolean {
-    // Original logic
-    // const rawContentDef = this._dragSource.content; // 'this' or 'draggedNodeInstance'
-    // const processedDragDef = this.em.Components.getNewComponentDragDef(rawContentDef);
-    // let sourceContent = (isFunction(rawContentDef) ? processedDragDef : rawContentDef) || this.model;
+    // Simplified and corrected logic:
+    // Always use the full component model of the CanvasNewComponentNode.
+    // 'this.model' if 'this' is the CanvasNewComponentNode, or 'draggedNodeInstance.model'.
+    let sourceContent = this.model;

     // ... rest of the method using sourceContent ...
   }
```

**Benefits:**
Significant Performance Improvement: Eliminates the expensive wrapper.append fallback in ComponentManager.canMove for new component drags, resulting in a much smoother and more responsive drag-and-drop experience.
Simplified Logic: Streamlines the logic within CanvasNewComponentNode.prototype.canMove by directly using the most appropriate representation (the full model) of the component being dragged.

**How to Test:**
On a version prior to this change, drag various new components (especially those with potentially more complex definitions or event handlers) from the blocks panel to the canvas and observe significant UI lag.
-> Apply this change.
Repeat the drag operations and confirm a noticeable improvement in responsiveness and reduction/elimination of lag.
Test with blocks defined by simple objects and by functions to ensure consistent behavior.

**Note:**
This change focuses specifically on the CanvasNewComponentNode and should not negatively impact canMove operations for components already existing on the canvas.

**Before**
![Before](https://github.com/user-attachments/assets/12b6992b-a036-4625-8f00-01d9f962e118)

**After**
![After](https://github.com/user-attachments/assets/9b33f131-7b11-4fee-8575-bd2d0584f471)
