### PR TITLE
Change dynamic style events behviour

### DIFF
--- a/packages/core/src/data_sources/model/DataResolverListener.ts
+++ b/packages/core/src/data_sources/model/DataResolverListener.ts
@@ -75,12 +75,11 @@ export default class DataResolverListener {
   private listenToDataVariable(dataVariable: DataVariable): ListenerWithCallback[] {
     const { em } = this;
     const dataListeners: ListenerWithCallback[] = [];
-    dataListeners.push(
-      this.createListener(dataVariable, 'change', () => {
-        this.listenToResolver();
-        this.onChange();
-      }),
-    );
+    const onChangeAndRewatch = () => {
+      this.listenToResolver();
+      this.onChange();
+    };
+    dataListeners.push(this.createListener(dataVariable, 'change', onChangeAndRewatch));
 
     const path = dataVariable.getResolverPath();
     if (!path) return dataListeners;
@@ -89,7 +88,7 @@ export default class DataResolverListener {
     const [ds, dr] = em.DataSources.fromPath(path!);
 
     if (ds) {
-      dataListeners.push(this.createListener(ds.records, 'add remove reset'));
+      dataListeners.push(this.createListener(ds.records, 'add remove reset', onChangeAndRewatch));
     }
 
     if (dr) {
@@ -97,7 +96,7 @@ export default class DataResolverListener {
     }
 
     dataListeners.push(
-      this.createListener(em.DataSources.all, 'add remove reset'),
+      this.createListener(em.DataSources.all, 'add remove reset', onChangeAndRewatch),
       this.createListener(em, `${DataSourcesEvents.path}:${normPath}`),
     );
 

--- a/packages/core/src/dom_components/model/ModelDataResolverWatchers.ts
+++ b/packages/core/src/dom_components/model/ModelDataResolverWatchers.ts
@@ -32,7 +32,7 @@ export class ModelDataResolverWatchers {
   }
 
   private onStyleUpdate(component: StyleableModel | undefined, key: string, value: any) {
-    component?.addStyle({ [key]: value }, { ...updateFromWatcher, noEvent: true, partial: true, avoidStore: true });
+    component?.addStyle({ [key]: value }, { ...updateFromWatcher, partial: true, avoidStore: true });
   }
 
   bindModel(model: StyleableModel) {

--- a/packages/core/src/domain_abstract/model/StyleableModel.ts
+++ b/packages/core/src/domain_abstract/model/StyleableModel.ts
@@ -91,7 +91,7 @@ export default class StyleableModel<T extends ObjectHash = any> extends Model<T,
       prop = this.parseStyle(prop);
     }
 
-    const propOrig = this.getStyle({ skipResolve: true });
+    const propOrig = this.getStyle('', { skipResolve: true });
 
     if (opts.partial || opts.avoidStore) {
       opts.avoidStore = true;
@@ -114,7 +114,13 @@ export default class StyleableModel<T extends ObjectHash = any> extends Model<T,
 
     this.set('style', newStyle, opts as any);
 
-    const diff = shallowDiff(propOrig, newStyle);
+    const changedKeys = Object.keys(shallowDiff(propOrig, propNew));
+    const diff: ObjectAny = changedKeys.reduce((acc, key) => {
+      return {
+        ...acc,
+        [key]: newStyle[key],
+      };
+    }, {});
     // Delete the property used for partial updates
     delete diff.__p;
 


### PR DESCRIPTION
Some changes to how style changes, particularly those tied to data sources, trigger events:

* **Enable Event Emission for Data-Bound Styles:** Allow events to be emitted when styles even if a style is bound to a data source. This will enable real-time UI updates as the underlying data changes.
* **Emit Events on Data Source Value Changes:** When a style's value changes due to an update in its bound data source (e.g., `em.Datasource.get('ds').setRecord()`), an event like `em.emit(change:style:STYLE_NAME)` should be emitted. This provides a clear signal that a specific style has been updated.
* **Fix Event Emission for Redundant Data Bindings:** An event should still be emitted even when binding a style to a data source with a value that is identical to its previous static value. For example, if `cmp.getStyle('width')` currently returns '100px' and you then set `cmp.setStyle({width: {type: 'data-variable', path: 'some_path.to.100px'}})` (assuming the data variable also resolves to '100px'), an event should still be triggered to indicate the change in binding type, even if the visual outcome is the same.
* **Fix Listening to Data Source Changes After Project Load:** Updating values had some bugs if the data source or record was added after the dynamic value was added to components.