### PR TITLE
Fix parser to take account of `parser.optionsHtml.keepEmptyTextNodes` option

### DIFF
--- a/packages/core/src/editor/config/config.ts
+++ b/packages/core/src/editor/config/config.ts
@@ -205,12 +205,6 @@ export interface EditorConfig {
   tagVarEnd?: string;
 
   /**
-   * When false, removes empty text nodes when parsed, unless they contain a space.
-   * @default false
-   */
-  keepEmptyTextNodes?: boolean;
-
-  /**
    * Return JS of components inside HTML from 'editor.getHtml()'.
    * @default true
    */
@@ -461,7 +455,6 @@ const config: () => EditorConfig = () => ({
   mediaCondition: 'max-width',
   tagVarStart: '{[ ',
   tagVarEnd: ' ]}',
-  keepEmptyTextNodes: false,
   jsInHtml: true,
   nativeDnD: true,
   multipleSelection: true,

--- a/packages/core/src/parser/model/ParserHtml.ts
+++ b/packages/core/src/parser/model/ParserHtml.ts
@@ -325,7 +325,6 @@ const ParserHtml = (em?: EditorModel, config: ParserConfig & { returnArray?: boo
       const conf = em?.get('Config') || {};
       const Parser = em?.Parser;
       const res: HTMLParseResult = { html: [] };
-      const cf = { ...config, ...opts };
       const preOptions = {
         ...config.optionsHtml,
         // @ts-ignore Support previous `configParser.htmlType` option
@@ -336,6 +335,7 @@ const ParserHtml = (em?: EditorModel, config: ParserConfig & { returnArray?: boo
         ...preOptions,
         asDocument: this.__checkAsDocument(str, preOptions),
       };
+      const cf = { ...config, ...options };
       const { preParser, asDocument } = options;
       const inputOptions = { input: isFunction(preParser) ? preParser(str, { editor: em?.getEditor()! }) : str };
       Parser?.__emitEvent(ParserEvents.htmlBefore, inputOptions);

--- a/packages/core/test/specs/parser/model/ParserHtml.ts
+++ b/packages/core/test/specs/parser/model/ParserHtml.ts
@@ -983,4 +983,43 @@ describe('ParserHtml', () => {
       expect(obj.parse(str).html).toEqual(result);
     });
   });
+
+  describe('with keepEmptyTextNodes ON', () => {
+    beforeEach(() => {
+      obj = ParserHtml(em, {
+        returnArray: true,
+        optionsHtml: { keepEmptyTextNodes: true },
+      });
+      obj.compTypes = em.Components.componentTypes;
+    });
+
+    test('Keep empty whitespaces', () => {
+      const str = `<div>
+        <p>TestText</p>
+      </div>`;
+      const result = [
+        {
+          tagName: 'div',
+          components: [
+            {
+              tagName: '',
+              type: 'textnode',
+              content: '\n        ',
+            },
+            {
+              tagName: 'p',
+              components: { type: 'textnode', content: 'TestText' },
+              type: 'text',
+            },
+            {
+              tagName: '',
+              type: 'textnode',
+              content: '\n      ',
+            },
+          ],
+        },
+      ];
+      expect(obj.parse(str).html).toEqual(result);
+    });
+  });
 });


### PR DESCRIPTION
According to type definition, `parser.optionsHtml` option has `keepEmptyTextNodes` property but setting the property has no effect.

This pull request makes HTML parser to take account of `parser.optionsHtml.keepEmptyTextNodes` option.

Fix #6570 