### PR TITLE
Data source schema & providers

### DIFF
--- a/docs/api.mjs
+++ b/docs/api.mjs
@@ -97,7 +97,8 @@ async function generateDocs() {
         throw `File not found '${filePath}'`;
       }
 
-      return build([filePath], { shallow: true })
+      try {
+        return build([filePath], { shallow: true })
         .then((cm) => formats.md(cm /*{ markdownToc: true }*/))
         .then(async (output) => {
           let addLogs = [];
@@ -114,16 +115,25 @@ async function generateDocs() {
 
           // Search for module event documentation
           if (result.indexOf(REPLACE_EVENTS) >= 0) {
-            const eventsMd = await getEventsMdFromTypes(filePath);
-            if (eventsMd && result.indexOf(REPLACE_EVENTS) >= 0) {
-              addLogs.push('replaced events');
+            try {
+              const eventsMd = await getEventsMdFromTypes(filePath);
+              if (eventsMd && result.indexOf(REPLACE_EVENTS) >= 0) {
+                addLogs.push('replaced events');
+              }
+              result = eventsMd ? result.replace(REPLACE_EVENTS, `## Available Events\n${eventsMd}`) : result;
+            } catch (err) {
+              console.error(`Failed getting events: ${file[0]}`)
+              throw err;
             }
-            result = eventsMd ? result.replace(REPLACE_EVENTS, `## Available Events\n${eventsMd}`) : result;
           }
 
           writeFileSync(`${docRoot}/api/${file[1]}`, result);
           log('Created', file[1], addLogs.length ? `(${addLogs.join(', ')})` : '');
         });
+      } catch (err) {
+        console.error(`Build failed: ${file[0]}`)
+        throw err;
+      }
     }),
   );
 

--- a/docs/api.mjs
+++ b/docs/api.mjs
@@ -99,39 +99,39 @@ async function generateDocs() {
 
       try {
         return build([filePath], { shallow: true })
-        .then((cm) => formats.md(cm /*{ markdownToc: true }*/))
-        .then(async (output) => {
-          let addLogs = [];
-          let result = output
-            .replace(/\*\*\\\[/g, '**[')
-            .replace(/\*\*\(\\\[/g, '**([')
-            .replace(/<\\\[/g, '<[')
-            .replace(/<\(\\\[/g, '<([')
-            .replace(/\| \\\[/g, '| [')
-            .replace(/\\n```js/g, '```js')
-            .replace(/docsjs\./g, '')
-            .replace('**Extends ModuleModel**', '')
-            .replace('**Extends Model**', '');
+          .then((cm) => formats.md(cm /*{ markdownToc: true }*/))
+          .then(async (output) => {
+            let addLogs = [];
+            let result = output
+              .replace(/\*\*\\\[/g, '**[')
+              .replace(/\*\*\(\\\[/g, '**([')
+              .replace(/<\\\[/g, '<[')
+              .replace(/<\(\\\[/g, '<([')
+              .replace(/\| \\\[/g, '| [')
+              .replace(/\\n```js/g, '```js')
+              .replace(/docsjs\./g, '')
+              .replace('**Extends ModuleModel**', '')
+              .replace('**Extends Model**', '');
 
-          // Search for module event documentation
-          if (result.indexOf(REPLACE_EVENTS) >= 0) {
-            try {
-              const eventsMd = await getEventsMdFromTypes(filePath);
-              if (eventsMd && result.indexOf(REPLACE_EVENTS) >= 0) {
-                addLogs.push('replaced events');
+            // Search for module event documentation
+            if (result.indexOf(REPLACE_EVENTS) >= 0) {
+              try {
+                const eventsMd = await getEventsMdFromTypes(filePath);
+                if (eventsMd && result.indexOf(REPLACE_EVENTS) >= 0) {
+                  addLogs.push('replaced events');
+                }
+                result = eventsMd ? result.replace(REPLACE_EVENTS, `## Available Events\n${eventsMd}`) : result;
+              } catch (err) {
+                console.error(`Failed getting events: ${file[0]}`);
+                throw err;
               }
-              result = eventsMd ? result.replace(REPLACE_EVENTS, `## Available Events\n${eventsMd}`) : result;
-            } catch (err) {
-              console.error(`Failed getting events: ${file[0]}`)
-              throw err;
             }
-          }
 
-          writeFileSync(`${docRoot}/api/${file[1]}`, result);
-          log('Created', file[1], addLogs.length ? `(${addLogs.join(', ')})` : '');
-        });
+            writeFileSync(`${docRoot}/api/${file[1]}`, result);
+            log('Created', file[1], addLogs.length ? `(${addLogs.join(', ')})` : '');
+          });
       } catch (err) {
-        console.error(`Build failed: ${file[0]}`)
+        console.error(`Build failed: ${file[0]}`);
         throw err;
       }
     }),

--- a/docs/api/block_manager.md
+++ b/docs/api/block_manager.md
@@ -84,6 +84,8 @@ editor.on('block:custom', ({ container, blocks, ... }) => { ... });
 editor.on('block', ({ event, model, ... }) => { ... });
 ```
 
+* BlocksEventCallback
+
 [Block]: block.html
 
 [Component]: component.html

--- a/docs/api/canvas.md
+++ b/docs/api/canvas.md
@@ -122,6 +122,14 @@ editor.on('canvas:frame:load:body', ({ window }) => {
 });
 ```
 
+* `canvas:frame:unload` Frame is unloading from the canvas.
+
+```javascript
+editor.on('canvas:frame:unload', ({ frame }) => {
+ console.log('Unloading frame', frame);
+});
+```
+
 [Component]: component.html
 
 [Frame]: frame.html

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -137,7 +137,7 @@ By setting override to specific properties, changes of those properties will be 
 ### Parameters
 
 *   `value` **([Boolean][3] | [String][1] | [Array][5]<[String][1]>)**&#x20;
-*   `options` **DynamicWatchersOptions**  (optional, default `{}`)
+*   `options` **DataWatchersOptions**  (optional, default `{}`)
 
 ### Examples
 
@@ -335,8 +335,7 @@ Get the style of the component
 
 ### Parameters
 
-*   `options` **any**  (optional, default `{}`)
-*   `optsAdd` **any**  (optional, default `{}`)
+*   `opts` **GetComponentStyleOpts?**&#x20;
 
 Returns **[Object][2]**&#x20;
 
@@ -363,7 +362,7 @@ Return all component's attributes
 
 ### Parameters
 
-*   `opts` **{noClass: [boolean][3]?, noStyle: [boolean][3]?}**  (optional, default `{}`)
+*   `opts` **{noClass: [boolean][3]?, noStyle: [boolean][3]?, skipResolve: [boolean][3]?}**  (optional, default `{}`)
 
 Returns **[Object][2]**&#x20;
 

--- a/docs/api/datasource.md
+++ b/docs/api/datasource.md
@@ -31,6 +31,44 @@ dataSource.addRecord({ id: 'id3', name: 'value3' });
 *   `props` **DataSourceProps** Properties to initialize the data source.
 *   `opts` **DataSourceOptions** Options to initialize the data source.
 
+### hasProvider
+
+Indicates if the data source has a provider for records.
+
+### getResolvedRecords
+
+Retrieves all records from the data source with resolved relations based on the schema.
+
+### upSchema
+
+Update the schema.
+
+#### Parameters
+
+*   `schema` **Partial\<any>**&#x20;
+*   `opts` **SetOptions?**&#x20;
+
+#### Examples
+
+```javascript
+dataSource.upSchema({ name: { type: 'string' } });
+```
+
+### getSchemaField
+
+Get schema field definition.
+
+#### Parameters
+
+*   `fieldKey` **any**&#x20;
+
+#### Examples
+
+```javascript
+const fieldSchema = dataSource.getSchemaField('name');
+fieldSchema.type; // 'string'
+```
+
 ## defaults
 
 Returns the default properties for the data source.
@@ -48,6 +86,12 @@ If the `records` property is not an instance of `DataRecords`, it will be conver
 
 *   `props` **DataSourceProps\<DRProps>** Properties to initialize the data source.
 *   `opts` **DataSourceOptions** Options to initialize the data source.
+
+## records
+
+Retrieves the collection of records associated with this data source.
+
+Returns **DataRecords\<DRProps>** The collection of data records.
 
 ## records
 

--- a/docs/api/datasources.md
+++ b/docs/api/datasources.md
@@ -44,11 +44,25 @@ editor.on('data:path', ({ dataSource, dataRecord, path }) => {
 editor.on('data:pathSource:SOURCE_ID', ({ dataSource, dataRecord, path }) => { ... });
 ```
 
+* `data:provider:load` Data source provider load.
+
+```javascript
+editor.on('data:provider:load', ({ dataSource, result }) => { ... });
+```
+
+* `data:provider:loadAll` Load of all data source providers (eg. on project load).
+
+```javascript
+editor.on('data:provider:loadAll', () => { ... });
+```
+
 * `data` Catch-all event for all the events mentioned above.
 
 ```javascript
 editor.on('data', ({ event, model, ... }) => { ... });
 ```
+
+* DataSourcesEventCallback
 
 ## Methods
 
@@ -101,14 +115,31 @@ Returns **[DataSource]** Data source.
 
 ## getValue
 
-Get value from data sources by key
+Get value from data sources by path.
 
 ### Parameters
 
-*   `key` **[String][7]** Path to value.
-*   `defValue` **any**&#x20;
+*   `path` **[String][7]** Path to value.
+*   `defValue` **any** Default value if the path is not found.
 
 Returns **any** const value = dsm.getValue('ds\_id.record\_id.propName', 'defaultValue');
+
+## setValue
+
+Set value in data sources by path.
+
+### Parameters
+
+*   `path` **[String][7]** Path to value in format 'dataSourceId.recordId.propName'
+*   `value` **any** Value to set
+
+### Examples
+
+```javascript
+dsm.setValue('ds_id.record_id.propName', 'new value');
+```
+
+Returns **[Boolean][8]** Returns true if the value was set successfully
 
 ## remove
 
@@ -152,7 +183,7 @@ data record, and optional property path.
 
 Store data sources to a JSON object.
 
-Returns **[Array][8]** Stored data sources.
+Returns **[Array][9]** Stored data sources.
 
 ## load
 
@@ -178,4 +209,6 @@ Returns **[Object][6]** Loaded data sources.
 
 [7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array

--- a/docs/api/device_manager.md
+++ b/docs/api/device_manager.md
@@ -19,12 +19,35 @@ const deviceManager = editor.Devices;
 ```
 
 ## Available Events
+* `device:add` New device added to the collection. The `Device` is passed as an argument.
 
-*   `device:add` - Added new device. The [Device] is passed as an argument to the callback
-*   `device:remove` - Device removed. The [Device] is passed as an argument to the callback
-*   `device:select` - New device selected. The newly selected [Device] and the previous one, are passed as arguments to the callback
-*   `device:update` - Device updated. The updated [Device] and the object containing changes are passed as arguments to the callback
-*   `device` - Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback
+```javascript
+editor.on('device:add', (device) => { ... });
+```
+
+* `device:remove` Device removed from the collection. The `Device` is passed as an argument.
+
+```javascript
+editor.on('device:remove', (device) => { ... });
+```
+
+* `device:select` A new device is selected. The `Device` is passed as an argument.
+
+```javascript
+editor.on('device:select', (device) => { ... });
+```
+
+* `device:update` Device updated. The `Device` and the object containing changes are passed as arguments.
+
+```javascript
+editor.on('device:update', (device) => { ... });
+```
+
+* `device` Catch-all event for all the events mentioned above.
+
+```javascript
+editor.on('device', ({ event, model, ... }) => { ... });
+```
 
 ## Methods
 

--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -42,6 +42,15 @@ editor.on('load', () => { ... });
 editor.on('project:load', ({ project, initial }) => { ... });
 ```
 
+* `project:loaded` Similar to `project:load`, but triggers only if the project is loaded successfully.
+
+```javascript
+editor.on('project:loaded', ({ project, initial }) => { ... });
+
+// Loading an empty project, won't trigger this event.
+editor.loadProjectData({});
+```
+
 * `project:get` Event triggered on request of the project data. This can be used to extend the project with custom data.
 
 ```javascript
@@ -516,6 +525,7 @@ Load data from the JSON project
 ### Parameters
 
 *   `data` **[Object][16]** Project to load
+*   `options` **[Object][16]?** Custom options that could be passed to the project load events. (optional, default `{}`)
 
 ### Examples
 
@@ -722,7 +732,7 @@ Trigger event
 ### Parameters
 
 *   `event` **[string][18]** Event to trigger
-*   `args` **...[Array][19]\<any>**&#x20;
+*   `args` **...any**&#x20;
 
 Returns **this**&#x20;
 

--- a/docs/api/keymaps.md
+++ b/docs/api/keymaps.md
@@ -19,23 +19,30 @@ const editor = grapesjs.init({
 })
 ```
 
-Once the editor is instantiated you can use its API and listen to its events. Before using these methods, you should get the module from the instance.
+Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
 
 ```js
-// Listen to events
-editor.on('keymap:add', () => { ... });
-
-// Use the API
 const keymaps = editor.Keymaps;
-keymaps.add(...);
 ```
 
 ## Available Events
+* `keymap:add` New keymap added. The new keymap object is passed as an argument to the callback.
 
-*   `keymap:add` - New keymap added. The new keyamp object is passed as an argument
-*   `keymap:remove` - Keymap removed. The removed keyamp object is passed as an argument
-*   `keymap:emit` - Some keymap emitted, in arguments you get keymapId, shortcutUsed, Event
-*   `keymap:emit:{keymapId}` - `keymapId` emitted, in arguments you get keymapId, shortcutUsed, Event
+```javascript
+editor.on('keymap:add', (keymap) => { ... });
+```
+
+* `keymap:remove` Keymap removed. The removed keymap object is passed as an argument to the callback.
+
+```javascript
+editor.on('keymap:remove', (keymap) => { ... });
+```
+
+* `keymap:emit` Some keymap emitted. The keymapId, shortcutUsed, and Event are passed as arguments to the callback.
+
+```javascript
+editor.on('keymap:emit', (keymapId, shortcutUsed, event) => { ... });
+```
 
 ## Methods
 

--- a/docs/api/layer_manager.md
+++ b/docs/api/layer_manager.md
@@ -13,16 +13,30 @@ const editor = grapesjs.init({
 })
 ```
 
-Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance
+Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
 
 ```js
 const layers = editor.Layers;
 ```
 
 ## Available Events
+* `layer:root` Root layer changed. The new root component is passed as an argument to the callback.
 
-*   `layer:root` - Root layer changed. The new root component is passed as an argument to the callback.
-*   `layer:component` - Component layer is updated. The updated component is passed as an argument to the callback.
+```javascript
+editor.on('layer:root', (component) => { ... });
+```
+
+* `layer:component` Component layer is updated. The updated component is passed as an argument to the callback.
+
+```javascript
+editor.on('layer:component', (component, opts) => { ... });
+```
+
+* `layer:custom` Custom layer event. Object with container and root is passed as an argument to the callback.
+
+```javascript
+editor.on('layer:custom', ({ container, root }) => { ... });
+```
 
 ## Methods
 

--- a/docs/api/modal_dialog.md
+++ b/docs/api/modal_dialog.md
@@ -19,10 +19,23 @@ const modal = editor.Modal;
 ```
 
 ## Available Events
+* `modal:open` Modal is opened
 
-*   `modal:open` - Modal is opened
-*   `modal:close` - Modal is closed
-*   `modal` - Event triggered on any change related to the modal. An object containing all the available data about the triggered event is passed as an argument to the callback.
+```javascript
+editor.on('modal:open', () => { ... });
+```
+
+* `modal:close` Modal is closed
+
+```javascript
+editor.on('modal:close', () => { ... });
+```
+
+* `modal` Event triggered on any change related to the modal. An object containing all the available data about the triggered event is passed as an argument to the callback.
+
+```javascript
+editor.on('modal', ({ open, title, content, ... }) => { ... });
+```
 
 ## Methods
 

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -81,6 +81,12 @@ Parse HTML string and return the object containing the Component Definition
     *   `options.htmlType` **[String][6]?** [HTML mime type][7] to parse
     *   `options.allowScripts` **[Boolean][8]** Allow `<script>` tags (optional, default `false`)
     *   `options.allowUnsafeAttr` **[Boolean][8]** Allow unsafe HTML attributes (eg. `on*` inline event handlers) (optional, default `false`)
+    *   `options.allowUnsafeAttrValue` **[Boolean][8]** Allow unsafe HTML attribute values (eg. `src="javascript:..."`) (optional, default `false`)
+    *   `options.keepEmptyTextNodes` **[Boolean][8]** Keep whitespaces regardless of whether they are meaningful (optional, default `false`)
+    *   `options.asDocument` **[Boolean][8]?** Treat the HTML string as document
+    *   `options.detectDocument` **([Boolean][8] | [Function][9])?** Indicate if or how to detect if the HTML string should be treated as document
+    *   `options.preParser` **[Function][9]?** How to pre-process the HTML string before parsing
+    *   `options.convertDataGjsAttributesHyphens` **[Boolean][8]** Convert `data-gjs-*` attributes from hyphenated to camelCase (eg. `data-gjs-my-component` to `data-gjs-myComponent`) (optional, default `false`)
 
 ### Examples
 
@@ -113,7 +119,7 @@ const res = Parser.parseCss('.cls { color: red }');
 // [{ ... }]
 ```
 
-Returns **[Array][9]<[Object][5]>** Array containing the result
+Returns **[Array][10]<[Object][5]>** Array containing the result
 
 [1]: https://github.com/GrapesJS/grapesjs/blob/master/src/parser/config/config.ts
 
@@ -131,4 +137,6 @@ Returns **[Array][9]<[Object][5]>** Array containing the result
 
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+
+[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array

--- a/docs/api/rich_text_editor.md
+++ b/docs/api/rich_text_editor.md
@@ -15,21 +15,30 @@ const editor = grapesjs.init({
 })
 ```
 
-Once the editor is instantiated you can use its API and listen to its events. Before using these methods, you should get the module from the instance.
+Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
 
 ```js
-// Listen to events
-editor.on('rte:enable', () => { ... });
-
-// Use the API
 const rte = editor.RichTextEditor;
-rte.add(...);
 ```
 
 ## Available Events
+* `rte:enable` RTE enabled. The view, on which RTE is enabled, and the RTE instance are passed as arguments.
 
-*   `rte:enable` - RTE enabled. The view, on which RTE is enabled, is passed as an argument
-*   `rte:disable` - RTE disabled. The view, on which RTE is disabled, is passed as an argument
+```javascript
+editor.on('rte:enable', (view, rte) => { ... });
+```
+
+* `rte:disable` RTE disabled. The view, on which RTE is disabled, and the RTE instance are passed as arguments.
+
+```javascript
+editor.on('rte:disable', (view, rte) => { ... });
+```
+
+* `rte:custom` Custom RTE event. Object with enabled status, container, and actions is passed as an argument.
+
+```javascript
+editor.on('rte:custom', ({ enabled, container, actions }) => { ... });
+```
 
 ## Methods
 

--- a/docs/api/selector_manager.md
+++ b/docs/api/selector_manager.md
@@ -35,24 +35,56 @@ const editor = grapesjs.init({
 })
 ```
 
-Once the editor is instantiated you can use its API and listen to its events. Before using these methods, you should get the module from the instance.
+Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
 
 ```js
-// Listen to events
-editor.on('selector:add', (selector) => { ... });
-
-// Use the API
 const sm = editor.Selectors;
-sm.add(...);
 ```
 
 ## Available Events
+* `selector:add` Selector added. The Selector is passed as an argument to the callback.
 
-*   `selector:add` - Selector added. The [Selector] is passed as an argument to the callback.
-*   `selector:remove` - Selector removed. The [Selector] is passed as an argument to the callback.
-*   `selector:update` - Selector updated. The [Selector] and the object containing changes are passed as arguments to the callback.
-*   `selector:state` - States changed. An object containing all the available data about the triggered event is passed as an argument to the callback.
-*   `selector` - Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback.
+```javascript
+editor.on('selector:add', (selector) => { ... });
+```
+
+* `selector:remove` Selector removed. The Selector is passed as an argument to the callback.
+
+```javascript
+editor.on('selector:remove', (selector) => { ... });
+```
+
+* `selector:remove:before` Before selector remove. The Selector is passed as an argument to the callback.
+
+```javascript
+editor.on('selector:remove:before', (selector) => { ... });
+```
+
+* `selector:update` Selector updated. The Selector and the object containing changes are passed as arguments to the callback.
+
+```javascript
+editor.on('selector:update', (selector, changes) => { ... });
+```
+
+* `selector:state` States changed. An object containing all the available data about the triggered event is passed as an argument to the callback.
+
+```javascript
+editor.on('selector:state', (state) => { ... });
+```
+
+* `selector:custom` Custom selector event. An object containing states, selected selectors, and container is passed as an argument.
+
+```javascript
+editor.on('selector:custom', ({ states, selected, container }) => { ... });
+```
+
+* `selector` Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback.
+
+```javascript
+editor.on('selector', ({ event, selector, changes, ... }) => { ... });
+```
+
+* SelectorStringObject
 
 ## Methods
 

--- a/docs/api/style_manager.md
+++ b/docs/api/style_manager.md
@@ -13,32 +13,72 @@ const editor = grapesjs.init({
 })
 ```
 
-Once the editor is instantiated you can use its API and listen to its events. Before using these methods, you should get the module from the instance.
+Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
 
 ```js
-// Listen to events
-editor.on('style:sector:add', (sector) => { ... });
-
-// Use the API
 const styleManager = editor.StyleManager;
-styleManager.addSector(...);
 ```
 
 ## Available Events
+* `style:sector:add` Sector added. The Sector is passed as an argument to the callback.
 
-*   `style:sector:add` - Sector added. The [Sector] is passed as an argument to the callback.
-*   `style:sector:remove` - Sector removed. The [Sector] is passed as an argument to the callback.
-*   `style:sector:update` - Sector updated. The [Sector] and the object containing changes are passed as arguments to the callback.
-*   `style:property:add` - Property added. The [Property] is passed as an argument to the callback.
-*   `style:property:remove` - Property removed. The [Property] is passed as an argument to the callback.
-*   `style:property:update` - Property updated. The [Property] and the object containing changes are passed as arguments to the callback.
-*   `style:target` - Target selection changed. The target (or `null` in case the target is deselected) is passed as an argument to the callback.
+```javascript
+editor.on('style:sector:add', (sector) => { ... });
+```
 
-<!--
-* `styleManager:update:target` - The target (Component or CSSRule) is changed
-* `styleManager:change` - Triggered on style property change from new selected component, the view of the property is passed as an argument to the callback
-* `styleManager:change:{propertyName}` - As above but for a specific style property
--->
+* `style:sector:remove` Sector removed. The Sector is passed as an argument to the callback.
+
+```javascript
+editor.on('style:sector:remove', (sector) => { ... });
+```
+
+* `style:sector:update` Sector updated. The Sector and the object containing changes are passed as arguments to the callback.
+
+```javascript
+editor.on('style:sector:update', (sector, changes) => { ... });
+```
+
+* `style:property:add` Property added. The Property is passed as an argument to the callback.
+
+```javascript
+editor.on('style:property:add', (property) => { ... });
+```
+
+* `style:property:remove` Property removed. The Property is passed as an argument to the callback.
+
+```javascript
+editor.on('style:property:remove', (property) => { ... });
+```
+
+* `style:property:update` Property updated. The Property and the object containing changes are passed as arguments to the callback.
+
+```javascript
+editor.on('style:property:update', (property, changes) => { ... });
+```
+
+* `style:target` Target selection changed. The target (or null in case the target is deselected) is passed as an argument to the callback.
+
+```javascript
+editor.on('style:target', (target) => { ... });
+```
+
+* `style:layer:select` Layer selected. Object containing layer data is passed as an argument.
+
+```javascript
+editor.on('style:layer:select', (data) => { ... });
+```
+
+* `style:custom` Custom style event. Object containing all custom data is passed as an argument.
+
+```javascript
+editor.on('style:custom', ({ container }) => { ... });
+```
+
+* `style` Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback.
+
+```javascript
+editor.on('style', ({ event, sector, property, ... }) => { ... });
+```
 
 ## Methods
 

--- a/packages/core/src/block_manager/types.ts
+++ b/packages/core/src/block_manager/types.ts
@@ -1,4 +1,5 @@
 import { ItemsByCategory } from '../abstract/ModuleCategory';
+import { AddOptions, RemoveOptions } from '../common';
 import Block from './model/Block';
 
 export interface BlocksByCategory extends ItemsByCategory<Block> {}
@@ -76,6 +77,12 @@ export enum BlocksEvents {
   all = 'block',
 }
 /**{END_EVENTS}*/
+
+export interface BlocksEventCallback {
+  [BlocksEvents.add]: [Block, AddOptions];
+  [BlocksEvents.remove]: [Block, RemoveOptions];
+  [BlocksEvents.update]: [Block, AddOptions];
+}
 
 // need this to avoid the TS documentation generator to break
 export default BlocksEvents;

--- a/packages/core/src/data_sources/config/config.ts
+++ b/packages/core/src/data_sources/config/config.ts
@@ -1,0 +1,13 @@
+export interface DataSourcesConfig {
+  /**
+   * If true, data source providers will be autoloaded on project load.
+   * @default false
+   */
+  autoloadProviders?: boolean;
+}
+
+const config: () => DataSourcesConfig = () => ({
+  autoloadProviders: false,
+});
+
+export default config;

--- a/packages/core/src/data_sources/index.ts
+++ b/packages/core/src/data_sources/index.ts
@@ -26,19 +26,20 @@ import { ItemManagerModule, ModuleConfig } from '../abstract/Module';
 import { AddOptions, collectionEvents, ObjectAny, RemoveOptions } from '../common';
 import EditorModel from '../editor/model/Editor';
 import { get, set, stringToPath } from '../utils/mixins';
+import defConfig, { DataSourcesConfig } from './config/config';
 import DataRecord from './model/DataRecord';
 import DataSource from './model/DataSource';
 import DataSources from './model/DataSources';
 import { DataSourcesEvents, DataSourceProps, DataRecordProps } from './types';
 import { Events } from 'backbone';
 
-export default class DataSourceManager extends ItemManagerModule<ModuleConfig, DataSources> {
+export default class DataSourceManager extends ItemManagerModule<DataSourcesConfig & ModuleConfig, DataSources> {
   storageKey = 'dataSources';
   events = DataSourcesEvents;
   destroy(): void {}
 
   constructor(em: EditorModel) {
-    super(em, 'DataSources', new DataSources([], em), DataSourcesEvents);
+    super(em, 'DataSources', new DataSources([], em), DataSourcesEvents, defConfig());
     Object.assign(this, Events); // Mixin Backbone.Events
   }
 
@@ -188,7 +189,24 @@ export default class DataSourceManager extends ItemManagerModule<ModuleConfig, D
    * @returns {Object} Loaded data sources.
    */
   load(data: any) {
-    return this.loadProjectData(data);
+    const { config, all, events, em } = this;
+    const result = this.loadProjectData(data);
+
+    if (config.autoloadProviders) {
+      const dsWithProviders = all.filter((ds) => ds.hasProvider);
+
+      if (!!dsWithProviders.length) {
+        const loadProviders = async () => {
+          em.trigger(events.providerLoadAllBefore);
+          const providersToLoad = dsWithProviders.map((ds) => ds.loadProvider());
+          await Promise.all(providersToLoad);
+          em.trigger(events.providerLoadAll);
+        };
+        loadProviders();
+      }
+    }
+
+    return result;
   }
 
   postLoad() {

--- a/packages/core/src/data_sources/index.ts
+++ b/packages/core/src/data_sources/index.ts
@@ -73,14 +73,14 @@ export default class DataSourceManager extends ItemManagerModule<ModuleConfig, D
   }
 
   /**
-   * Get value from data sources by key
-   * @param {String} key Path to value.
-   * @param {any} defValue
+   * Get value from data sources by path.
+   * @param {String} path Path to value.
+   * @param {any} defValue Default value if the path is not found.
    * @returns {any}
    * const value = dsm.getValue('ds_id.record_id.propName', 'defaultValue');
    */
-  getValue(key: string | string[], defValue: any) {
-    return get(this.getContext(), key, defValue);
+  getValue(path: string | string[], defValue?: any) {
+    return get(this.getContext(), path, defValue);
   }
 
   private getContext() {

--- a/packages/core/src/data_sources/index.ts
+++ b/packages/core/src/data_sources/index.ts
@@ -21,6 +21,7 @@
  * @module DataSources
  */
 
+import { isEmpty } from 'underscore';
 import { ItemManagerModule, ModuleConfig } from '../abstract/Module';
 import { AddOptions, collectionEvents, ObjectAny, RemoveOptions } from '../common';
 import EditorModel from '../editor/model/Editor';
@@ -164,15 +165,16 @@ export default class DataSourceManager extends ItemManagerModule<ModuleConfig, D
    * @returns {Array} Stored data sources.
    */
   store() {
-    const data: any[] = [];
+    const data: DataSourceProps[] = [];
     this.all.forEach((dataSource) => {
-      const skipFromStorage = dataSource.get('skipFromStorage');
+      const { skipFromStorage, transformers, records, schema, ...rest } = dataSource.attributes;
+
       if (!skipFromStorage) {
         data.push({
-          id: dataSource.id,
-          name: dataSource.get('name' as any),
-          records: dataSource.records.toJSON(),
-          skipFromStorage,
+          ...rest,
+          id: rest.id!,
+          schema: !isEmpty(schema) ? schema : undefined,
+          records: !rest.provider ? records : undefined,
         });
       }
     });

--- a/packages/core/src/data_sources/index.ts
+++ b/packages/core/src/data_sources/index.ts
@@ -24,7 +24,7 @@
 import { ItemManagerModule, ModuleConfig } from '../abstract/Module';
 import { AddOptions, collectionEvents, ObjectAny, RemoveOptions } from '../common';
 import EditorModel from '../editor/model/Editor';
-import { get, stringToPath } from '../utils/mixins';
+import { get, set, stringToPath } from '../utils/mixins';
 import DataRecord from './model/DataRecord';
 import DataSource from './model/DataSource';
 import DataSources from './model/DataSources';
@@ -95,8 +95,11 @@ export default class DataSourceManager extends ItemManagerModule<ModuleConfig, D
     const [ds, record, propPath] = this.fromPath(path);
 
     if (record && (propPath || propPath === '')) {
-      record.set(propPath, value);
-      return true;
+      let attrs = { ...record.attributes };
+      if (set(attrs, propPath || '', value)) {
+        record.set(attrs);
+        return true;
+      }
     }
 
     return false;

--- a/packages/core/src/data_sources/index.ts
+++ b/packages/core/src/data_sources/index.ts
@@ -83,6 +83,25 @@ export default class DataSourceManager extends ItemManagerModule<ModuleConfig, D
     return get(this.getContext(), path, defValue);
   }
 
+  /**
+   * Set value in data sources by path.
+   * @param {String} path Path to value in format 'dataSourceId/recordId/propName'
+   * @param {any} value Value to set
+   * @returns {Boolean} Returns true if the value was set successfully
+   * @example
+   * dsm.setValue('ds_id/record_id/propName', 'new value');
+   */
+  setValue(path: string, value: any) {
+    const [ds, record, propPath] = this.fromPath(path);
+
+    if (record && (propPath || propPath === '')) {
+      record.set(propPath, value);
+      return true;
+    }
+
+    return false;
+  }
+
   private getContext() {
     return this.all.reduce((acc, ds) => {
       acc[ds.id] = ds.records.reduce((accR, dr, i) => {

--- a/packages/core/src/data_sources/index.ts
+++ b/packages/core/src/data_sources/index.ts
@@ -85,11 +85,11 @@ export default class DataSourceManager extends ItemManagerModule<ModuleConfig, D
 
   /**
    * Set value in data sources by path.
-   * @param {String} path Path to value in format 'dataSourceId/recordId/propName'
+   * @param {String} path Path to value in format 'dataSourceId.recordId.propName'
    * @param {any} value Value to set
    * @returns {Boolean} Returns true if the value was set successfully
    * @example
-   * dsm.setValue('ds_id/record_id/propName', 'new value');
+   * dsm.setValue('ds_id.record_id.propName', 'new value');
    */
   setValue(path: string, value: any) {
     const [ds, record, propPath] = this.fromPath(path);

--- a/packages/core/src/data_sources/model/DataSource.ts
+++ b/packages/core/src/data_sources/model/DataSource.ts
@@ -38,7 +38,15 @@ import {
   SetOptions,
 } from '../../common';
 import EditorModel from '../../editor/model/Editor';
-import { DataSourceTransformers, DataSourceType, DataSourceProps, DataRecordProps } from '../types';
+import {
+  DataFieldPrimitiveType,
+  DataFieldSchemaRelation,
+  DataRecordProps,
+  DataSourceProps,
+  DataSourceTransformers,
+  DataSourceType,
+} from '../types';
+import { DEF_DATA_FIELD_ID } from '../utils';
 import DataRecord from './DataRecord';
 import DataRecords from './DataRecords';
 import DataSources from './DataSources';
@@ -153,8 +161,8 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
    * @returns {DataRecord<DRProps> | undefined} The data record, or `undefined` if no record is found with the given ID.
    * @name getRecord
    */
-  getRecord(id: string | number) {
-    return this.records.get(id) as DataRecord | undefined;
+  getRecord(id: string | number): DataRecord | undefined {
+    return this.records.get(id);
   }
 
   /**
@@ -166,6 +174,41 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
    */
   getRecords() {
     return [...this.records.models].map((record) => this.getRecord(record.id)!);
+  }
+
+  /**
+   * Retrieves all records from the data source with resolved relations based on the schema.
+   */
+  getResolvedRecords() {
+    const schemaEntries = Object.entries(this.schema);
+    const records = this.getRecords().map((record) => {
+      const result = { ...record.attributes };
+
+      if (schemaEntries.length === 0) return result;
+
+      schemaEntries.forEach(([fieldName, schema]) => {
+        const fieldSchema = schema as DataFieldSchemaRelation;
+        if (fieldSchema?.type === DataFieldPrimitiveType.relation && fieldSchema.target) {
+          const relationValue = result[fieldName];
+
+          if (relationValue) {
+            const targetDs = this.em.DataSources.get(fieldSchema.target);
+            if (targetDs) {
+              const targetField = fieldSchema.targetField || DEF_DATA_FIELD_ID;
+              const relatedRecord = targetDs.records.find((r) => r.attributes[targetField] === relationValue);
+
+              if (relatedRecord) {
+                result[fieldName] = relatedRecord.attributes;
+              }
+            }
+          }
+        }
+      });
+
+      return result;
+    });
+
+    return records;
   }
 
   /**

--- a/packages/core/src/data_sources/model/DataSource.ts
+++ b/packages/core/src/data_sources/model/DataSource.ts
@@ -29,6 +29,7 @@
  * @extends {Model<DataSourceProps>}
  */
 
+import { isString } from 'underscore';
 import {
   AddOptions,
   collectionEvents,
@@ -43,6 +44,7 @@ import {
   DataFieldSchemaRelation,
   DataRecordProps,
   DataSourceProps,
+  DataSourceProviderResult,
   DataSourceTransformers,
   DataSourceType,
 } from '../types';
@@ -217,6 +219,35 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
     });
 
     return records;
+  }
+
+  async loadProvider() {
+    const { provider } = this.attributes;
+
+    if (!provider) return;
+
+    if (isString(provider)) {
+      // TODO: implement providers as plugins (later)
+      return;
+    }
+
+    const providerGet = isString(provider.get) ? { url: provider.get } : provider.get;
+    const { url, method, headers, body } = providerGet;
+
+    const fetchProvider = async () => {
+      try {
+        const response = await fetch(url, { method, headers, body });
+        if (!response.ok) throw new Error(await response.text());
+        const providerResult: DataSourceProviderResult = await response.json();
+
+        if (providerResult?.records) this.setRecords(providerResult.records as any);
+        if (providerResult?.schema) this.upSchema(providerResult.schema);
+      } catch (error: any) {
+        this.em.logError(error.message);
+      }
+    };
+
+    await fetchProvider();
   }
 
   /**

--- a/packages/core/src/data_sources/model/DataSource.ts
+++ b/packages/core/src/data_sources/model/DataSource.ts
@@ -133,6 +133,13 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
   }
 
   /**
+   * Indicates if the data source has a provider for records.
+   */
+  get hasProvider() {
+    return !!this.attributes.provider;
+  }
+
+  /**
    * Handles the `add` event for records in the data source.
    * This method triggers a change event on the newly added record.
    *
@@ -222,7 +229,8 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
   }
 
   async loadProvider() {
-    const { provider } = this.attributes;
+    const { attributes, em } = this;
+    const { provider } = attributes;
 
     if (!provider) return;
 
@@ -235,15 +243,22 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
     const { url, method, headers, body } = providerGet;
 
     const fetchProvider = async () => {
+      const dataSource = this;
+
       try {
+        em.trigger(em.DataSources.events.providerLoadBefore, { dataSource });
+
         const response = await fetch(url, { method, headers, body });
         if (!response.ok) throw new Error(await response.text());
-        const providerResult: DataSourceProviderResult = await response.json();
+        const result: DataSourceProviderResult = await response.json();
 
-        if (providerResult?.records) this.setRecords(providerResult.records as any);
-        if (providerResult?.schema) this.upSchema(providerResult.schema);
+        if (result?.records) this.setRecords(result.records as any);
+        if (result?.schema) this.upSchema(result.schema);
+
+        em.trigger(em.DataSources.events.providerLoad, { result, dataSource });
       } catch (error: any) {
-        this.em.logError(error.message);
+        em.logError(error.message);
+        em.trigger(em.DataSources.events.providerLoadError, { dataSource, error });
       }
     };
 

--- a/packages/core/src/data_sources/model/DataSource.ts
+++ b/packages/core/src/data_sources/model/DataSource.ts
@@ -194,11 +194,19 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
           if (relationValue) {
             const targetDs = this.em.DataSources.get(fieldSchema.target);
             if (targetDs) {
+              const targetRecords = targetDs.records;
               const targetField = fieldSchema.targetField || DEF_DATA_FIELD_ID;
-              const relatedRecord = targetDs.records.find((r) => r.attributes[targetField] === relationValue);
 
-              if (relatedRecord) {
-                result[fieldName] = relatedRecord.attributes;
+              if (fieldSchema.isMany) {
+                const relationValues = Array.isArray(relationValue) ? relationValue : [relationValue];
+                const relatedRecords = targetRecords.filter((r) => relationValues.includes(r.attributes[targetField]));
+                result[fieldName] = relatedRecords.map((r) => ({ ...r.attributes }));
+              } else {
+                const relatedRecord = targetDs.records.find((r) => r.attributes[targetField] === relationValue);
+
+                if (relatedRecord) {
+                  result[fieldName] = { ...relatedRecord.attributes };
+                }
               }
             }
           }

--- a/packages/core/src/data_sources/model/DataSource.ts
+++ b/packages/core/src/data_sources/model/DataSource.ts
@@ -29,7 +29,14 @@
  * @extends {Model<DataSourceProps>}
  */
 
-import { AddOptions, collectionEvents, CombinedModelConstructorOptions, Model, RemoveOptions } from '../../common';
+import {
+  AddOptions,
+  collectionEvents,
+  CombinedModelConstructorOptions,
+  Model,
+  RemoveOptions,
+  SetOptions,
+} from '../../common';
 import EditorModel from '../../editor/model/Editor';
 import { DataSourceTransformers, DataSourceType, DataSourceProps, DataRecordProps } from '../types';
 import DataRecord from './DataRecord';
@@ -68,6 +75,7 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
   constructor(props: DataSourceProps<DRProps>, opts: DataSourceOptions) {
     super(
       {
+        schema: {},
         ...props,
         records: [],
       } as unknown as DataSourceType<DRProps>,
@@ -92,6 +100,16 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
    */
   get records() {
     return this.attributes.records as NonNullable<DataRecords<DRProps>>;
+  }
+
+  /**
+   * Retrieves the collection of records associated with this data source.
+   *
+   * @returns {DataRecords<DRProps>} The collection of data records.
+   * @name records
+   */
+  get schema() {
+    return this.attributes.schema!;
   }
 
   /**
@@ -180,6 +198,25 @@ export default class DataSource<DRProps extends DataRecordProps = DataRecordProp
     records.forEach((record) => {
       this.records.add(record);
     });
+  }
+
+  /**
+   * Update the schema.
+   * @example
+   * dataSource.upSchema({ name: { type: 'string' } });
+   */
+  upSchema(schema: Partial<typeof this.schema>, opts?: SetOptions) {
+    this.set('schema', { ...this.schema, ...schema }, opts);
+  }
+
+  /**
+   * Get schema field definition.
+   * @example
+   * const fieldSchema = dataSource.getSchemaField('name');
+   * fieldSchema.type; // 'string'
+   */
+  getSchemaField(fieldKey: keyof DRProps) {
+    return this.schema[fieldKey];
   }
 
   private handleChanges(m: any, c: any, o: any) {

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -118,13 +118,33 @@ export type DataSourceSchema<DR extends DataRecordProps = DataRecordProps> = {
   [K in keyof DR]?: DataFieldSchemas;
 };
 
+export interface DataSourceProviderMethodProps {
+  url: string;
+  method?: string;
+  headers?: HeadersInit;
+  body?: BodyInit;
+}
+
+export interface DataSourceProviderDefinitionProps {
+  get: string | DataSourceProviderMethodProps;
+}
+
+export interface DataSourceProviderResult {
+  records?: DataRecordProps[];
+  schema?: DataSourceSchema;
+}
+
+export type DataSourceProviderProp = string | DataSourceProviderDefinitionProps;
+
 export interface DataSourceType<DR extends DataRecordProps> extends BaseDataSource {
   records: DataRecords<DR>;
   schema: DataSourceSchema<DR>;
+  provider?: DataSourceProviderProp;
 }
-export interface DataSourceProps<DR extends DataRecordProps> extends BaseDataSource {
+export interface DataSourceProps<DR extends DataRecordProps = DataRecordProps> extends BaseDataSource {
   records?: DataRecords<DR> | DataRecord<DR>[] | DR[];
   schema?: DataSourceSchema<DR>;
+  provider?: DataSourceProviderProp;
 }
 export type RecordPropsType<T> = T extends DataRecord<infer U> ? U : never;
 export interface DataSourceTransformers {

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -46,6 +46,8 @@ interface BaseDataSource {
    * If true will store the data source in the GrapesJS project.json file.
    */
   skipFromStorage?: boolean;
+
+  [key: string]: unknown;
 }
 
 export enum DataFieldPrimitiveType {
@@ -214,6 +216,23 @@ export enum DataSourcesEvents {
    * editor.on('data:pathSource:SOURCE_ID', ({ dataSource, dataRecord, path }) => { ... });
    */
   pathSource = 'data:pathSource:',
+
+  /**
+   * @event `data:provider:load` Data source provider load.
+   * @example
+   * editor.on('data:provider:load', ({ dataSource, result }) => { ... });
+   */
+  providerLoad = 'data:provider:load',
+  providerLoadBefore = 'data:provider:load:before',
+  providerLoadError = 'data:provider:load:error',
+
+  /**
+   * @event `data:provider:loadAll` Load of all data source providers (eg. on project load).
+   * @example
+   * editor.on('data:provider:loadAll', () => { ... });
+   */
+  providerLoadAll = 'data:provider:loadAll',
+  providerLoadAllBefore = 'data:provider:loadAll:before',
 
   /**
    * @event `data` Catch-all event for all the events mentioned above.

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -124,7 +124,7 @@ export interface DataSourceType<DR extends DataRecordProps> extends BaseDataSour
 }
 export interface DataSourceProps<DR extends DataRecordProps> extends BaseDataSource {
   records?: DataRecords<DR> | DataRecord<DR>[] | DR[];
-  schema?: DataSourceType<DR>['schema'];
+  schema?: DataSourceSchema<DR>;
 }
 export type RecordPropsType<T> = T extends DataRecord<infer U> ? U : never;
 export interface DataSourceTransformers {

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -114,9 +114,13 @@ export type DataFieldSchemas =
   | DataFieldSchemaJSON
   | DataFieldSchemaRelation;
 
+export type DataSourceSchema<DR extends DataRecordProps = DataRecordProps> = {
+  [K in keyof DR]?: DataFieldSchemas;
+};
+
 export interface DataSourceType<DR extends DataRecordProps> extends BaseDataSource {
   records: DataRecords<DR>;
-  schema: Partial<Record<keyof DR, DataFieldSchemas | undefined>>;
+  schema: DataSourceSchema<DR>;
 }
 export interface DataSourceProps<DR extends DataRecordProps> extends BaseDataSource {
   records?: DataRecords<DR> | DataRecord<DR>[] | DR[];

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -1,9 +1,9 @@
-import { Model, Collection, ObjectAny, AddOptions, RemoveOptions } from '../common';
+import { AddOptions, Collection, Model, ObjectAny, RemoveOptions, SetOptions } from '../common';
 import DataRecord from './model/DataRecord';
 import DataRecords from './model/DataRecords';
 import DataSource from './model/DataSource';
 import DataVariable, { DataVariableProps } from './model/DataVariable';
-import { DataConditionProps, DataCondition } from './model/conditional_variables/DataCondition';
+import { DataCondition, DataConditionProps } from './model/conditional_variables/DataCondition';
 
 export type DataResolver = DataVariable | DataCondition;
 export type DataResolverProps = DataVariableProps | DataConditionProps;
@@ -250,6 +250,16 @@ export interface DataSourcesEventCallback {
   [DataSourcesEvents.add]: [DataSource, AddOptions];
   [DataSourcesEvents.remove]: [DataSource, RemoveOptions];
   [DataSourcesEvents.update]: [DataSource, AddOptions];
+  [DataSourcesEvents.path]: [{ dataSource: DataSource; dataRecord: DataRecord; path: string; options: SetOptions }];
+  [DataSourcesEvents.pathSource]: [
+    { dataSource: DataSource; dataRecord: DataRecord; path: string; options: SetOptions },
+  ];
+  [DataSourcesEvents.providerLoad]: [{ dataSource: DataSource; result: DataSourceProviderResult }];
+  [DataSourcesEvents.providerLoadBefore]: [{ dataSource: DataSource }];
+  [DataSourcesEvents.providerLoadError]: [{ dataSource: DataSource; error: Error }];
+  [DataSourcesEvents.providerLoadAll]: [];
+  [DataSourcesEvents.providerLoadAllBefore]: [];
+  [DataSourcesEvents.all]: [{ event: DataSourceEvent; model?: Model; options: ObjectAny }];
 }
 
 // need this to avoid the TS documentation generator to break

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -113,10 +113,11 @@ export type DataFieldSchemas =
 
 export interface DataSourceType<DR extends DataRecordProps> extends BaseDataSource {
   records: DataRecords<DR>;
-  schema: Record<keyof DR, DataFieldSchemas | undefined>;
+  schema: Partial<Record<keyof DR, DataFieldSchemas | undefined>>;
 }
 export interface DataSourceProps<DR extends DataRecordProps> extends BaseDataSource {
   records?: DataRecords<DR> | DataRecord<DR>[] | DR[];
+  schema?: DataSourceType<DR>['schema'];
 }
 export type RecordPropsType<T> = T extends DataRecord<infer U> ? U : never;
 export interface DataSourceTransformers {

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -54,67 +54,66 @@ export enum DataFieldPrimitiveType {
   boolean = 'boolean',
   date = 'date',
   json = 'json',
-  reference = 'reference',
+  relation = 'relation',
 }
 
-export type BaseFieldType =
-  | { type: DataFieldPrimitiveType.string }
-  | { type: DataFieldPrimitiveType.number }
-  | { type: DataFieldPrimitiveType.boolean }
-  | { type: DataFieldPrimitiveType.date }
-  | { type: DataFieldPrimitiveType.json }
-  | {
-      type: DataFieldPrimitiveType.reference;
-      target: string;
-      targetKey?: string;
-      isMany?: boolean;
-    };
+export interface DataFieldSchemaBase<T = unknown> {
+  default?: T;
+  description?: string;
+  label?: string;
+  [key: string]: unknown;
+  // order?: number;
+  // primary?: boolean;
+  // required?: boolean;
+  // unique?: boolean;
+  // validate?: (value: T, record: Record<string, any>) => boolean;
+}
 
-export interface DataFieldReferenceProps {
-  /** The target data source ID or name this field references */
+export interface DataFieldSchemaString extends DataFieldSchemaBase<string> {
+  type: DataFieldPrimitiveType.string;
+  enum?: string[];
+}
+
+export interface DataFieldSchemaNumber extends DataFieldSchemaBase<number> {
+  type: DataFieldPrimitiveType.number;
+}
+
+export interface DataFieldSchemaBoolean extends DataFieldSchemaBase<boolean> {
+  type: DataFieldPrimitiveType.boolean;
+}
+
+export interface DataFieldSchemaDate extends DataFieldSchemaBase<Date> {
+  type: DataFieldPrimitiveType.date;
+}
+
+export interface DataFieldSchemaJSON extends DataFieldSchemaBase<any> {
+  type: DataFieldPrimitiveType.json;
+}
+
+export interface DataFieldSchemaRelation extends DataFieldSchemaBase {
+  type: DataFieldPrimitiveType.relation;
+  /**
+   * The target data source ID
+   */
   target: string;
-
-  /** Optional key in the target data source */
-  targetKey?: string;
-
-  /** Relation type: one-to-one or one-to-many */
+  /**
+   * The target field in the data source
+   */
+  targetField?: string;
   isMany?: boolean;
 }
 
-export interface DataFieldSchema<T = any> {
-  type: DataFieldPrimitiveType | BaseFieldType;
-
-  /** Marks the field as the primary key (implies unique) */
-  primary?: boolean;
-
-  /** Field must be present in all records */
-  required?: boolean;
-
-  /** Value must be unique across all records */
-  unique?: boolean;
-
-  /** Default value when not provided in record */
-  default?: T;
-
-  /** Restrict allowed values */
-  enum?: T[];
-
-  /** Custom validator returning true if valid */
-  validate?: (value: T, record: Record<string, any>) => boolean;
-
-  /** Optional description, used for UI or docs */
-  description?: string;
-
-  /** Optional label, used for UI or docs */
-  label?: string;
-
-  /** Optional field order for rendering */
-  order?: number;
-}
+export type DataFieldSchemas =
+  | DataFieldSchemaString
+  | DataFieldSchemaNumber
+  | DataFieldSchemaBoolean
+  | DataFieldSchemaDate
+  | DataFieldSchemaJSON
+  | DataFieldSchemaRelation;
 
 export interface DataSourceType<DR extends DataRecordProps> extends BaseDataSource {
   records: DataRecords<DR>;
-  schema?: Record<string, DataFieldSchema>;
+  schema: Record<keyof DR, DataFieldSchemas | undefined>;
 }
 export interface DataSourceProps<DR extends DataRecordProps> extends BaseDataSource {
   records?: DataRecords<DR> | DataRecord<DR>[] | DR[];

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -47,8 +47,74 @@ interface BaseDataSource {
    */
   skipFromStorage?: boolean;
 }
+
+export enum DataFieldPrimitiveType {
+  string = 'string',
+  number = 'number',
+  boolean = 'boolean',
+  date = 'date',
+  json = 'json',
+  reference = 'reference',
+}
+
+export type BaseFieldType =
+  | { type: DataFieldPrimitiveType.string }
+  | { type: DataFieldPrimitiveType.number }
+  | { type: DataFieldPrimitiveType.boolean }
+  | { type: DataFieldPrimitiveType.date }
+  | { type: DataFieldPrimitiveType.json }
+  | {
+      type: DataFieldPrimitiveType.reference;
+      target: string;
+      targetKey?: string;
+      isMany?: boolean;
+    };
+
+export interface DataFieldReferenceProps {
+  /** The target data source ID or name this field references */
+  target: string;
+
+  /** Optional key in the target data source */
+  targetKey?: string;
+
+  /** Relation type: one-to-one or one-to-many */
+  isMany?: boolean;
+}
+
+export interface DataFieldSchema<T = any> {
+  type: DataFieldPrimitiveType | BaseFieldType;
+
+  /** Marks the field as the primary key (implies unique) */
+  primary?: boolean;
+
+  /** Field must be present in all records */
+  required?: boolean;
+
+  /** Value must be unique across all records */
+  unique?: boolean;
+
+  /** Default value when not provided in record */
+  default?: T;
+
+  /** Restrict allowed values */
+  enum?: T[];
+
+  /** Custom validator returning true if valid */
+  validate?: (value: T, record: Record<string, any>) => boolean;
+
+  /** Optional description, used for UI or docs */
+  description?: string;
+
+  /** Optional label, used for UI or docs */
+  label?: string;
+
+  /** Optional field order for rendering */
+  order?: number;
+}
+
 export interface DataSourceType<DR extends DataRecordProps> extends BaseDataSource {
   records: DataRecords<DR>;
+  schema?: Record<string, DataFieldSchema>;
 }
 export interface DataSourceProps<DR extends DataRecordProps> extends BaseDataSource {
   records?: DataRecords<DR> | DataRecord<DR>[] | DR[];

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -1,6 +1,7 @@
-import { Model, Collection, ObjectAny } from '../common';
+import { Model, Collection, ObjectAny, AddOptions, RemoveOptions } from '../common';
 import DataRecord from './model/DataRecord';
 import DataRecords from './model/DataRecords';
+import DataSource from './model/DataSource';
 import DataVariable, { DataVariableProps } from './model/DataVariable';
 import { DataConditionProps, DataCondition } from './model/conditional_variables/DataCondition';
 
@@ -175,6 +176,8 @@ export type DeepPartialDot<T> = {
       : never;
 };
 
+export type DataSourceEvent = `${DataSourcesEvents}`;
+
 /**{START_EVENTS}*/
 export enum DataSourcesEvents {
   /**
@@ -242,6 +245,12 @@ export enum DataSourcesEvents {
   all = 'data',
 }
 /**{END_EVENTS}*/
+
+export interface DataSourcesEventCallback {
+  [DataSourcesEvents.add]: [DataSource, AddOptions];
+  [DataSourcesEvents.remove]: [DataSource, RemoveOptions];
+  [DataSourcesEvents.update]: [DataSource, AddOptions];
+}
 
 // need this to avoid the TS documentation generator to break
 export default DataSourcesEvents;

--- a/packages/core/src/data_sources/types.ts
+++ b/packages/core/src/data_sources/types.ts
@@ -100,6 +100,9 @@ export interface DataFieldSchemaRelation extends DataFieldSchemaBase {
    * The target field in the data source
    */
   targetField?: string;
+  /**
+   * If true, the relation is one-to-many
+   */
   isMany?: boolean;
 }
 

--- a/packages/core/src/data_sources/utils.ts
+++ b/packages/core/src/data_sources/utils.ts
@@ -10,6 +10,8 @@ import { DataConditionIfFalseType, DataConditionIfTrueType } from './model/condi
 import { getSymbolMain } from '../dom_components/model/SymbolUtils';
 import Component from '../dom_components/model/Component';
 
+export const DEF_DATA_FIELD_ID = 'id';
+
 export function isDataResolverProps(value: any): value is DataResolverProps {
   return typeof value === 'object' && [DataVariableType, DataConditionType].includes(value?.type);
 }

--- a/packages/core/src/device_manager/index.ts
+++ b/packages/core/src/device_manager/index.ts
@@ -13,12 +13,7 @@
  * ```js
  * const deviceManager = editor.Devices;
  * ```
- * ## Available Events
- * * `device:add` - Added new device. The [Device] is passed as an argument to the callback
- * * `device:remove` - Device removed. The [Device] is passed as an argument to the callback
- * * `device:select` - New device selected. The newly selected [Device] and the previous one, are passed as arguments to the callback
- * * `device:update` - Device updated. The updated [Device] and the object containing changes are passed as arguments to the callback
- * * `device` - Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback
+ * {REPLACE_EVENTS}
  *
  * ## Methods
  * * [add](#add)

--- a/packages/core/src/dom_components/view/ComponentTextView.ts
+++ b/packages/core/src/dom_components/view/ComponentTextView.ts
@@ -248,9 +248,11 @@ export default class ComponentTextView<TComp extends ComponentText = ComponentTe
     mixins.off(elDocs, 'mousedown', this.onDisable as any);
     mixins[method](elDocs, 'mousedown', this.onDisable as any);
     em[method]('toolbar:run:before', this.onDisable);
+
     if (model) {
+      const rteEvents = em.RichTextEditor.events;
       model[method]('removed', this.onDisable);
-      model.trigger(`rte:${enable ? 'enable' : 'disable'}`);
+      model.trigger(enable ? rteEvents.enable : rteEvents.disable);
     }
 
     // @ts-ignore Avoid closing edit mode on component click

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -44,43 +44,49 @@
  */
 import { IBaseModule } from '../abstract/Module';
 import AssetManager from '../asset_manager';
-import { AssetEvent } from '../asset_manager/types';
-import BlockManager, { BlockEvent } from '../block_manager';
-import CanvasModule, { CanvasEvent } from '../canvas';
+import BlockManager from '../block_manager';
+import CanvasModule from '../canvas';
 import CodeManagerModule from '../code_manager';
-import CommandsModule, { CommandEvent } from '../commands';
-import { AddOptions, EventHandler, LiteralUnion } from '../common';
+import CommandsModule from '../commands';
+import { AddOptions, EventHandler } from '../common';
 import CssComposer from '../css_composer';
 import CssRule from '../css_composer/model/CssRule';
 import CssRules from '../css_composer/model/CssRules';
 import DataSourceManager from '../data_sources';
 import DeviceManager from '../device_manager';
-import ComponentManager, { ComponentEvent } from '../dom_components';
+import ComponentManager from '../dom_components';
 import Component from '../dom_components/model/Component';
 import Components from '../dom_components/model/Components';
 import ComponentWrapper from '../dom_components/model/ComponentWrapper';
 import { AddComponentsOption, ComponentAdd, DragMode } from '../dom_components/model/types';
 import StyleableModel from '../domain_abstract/model/StyleableModel';
 import I18nModule from '../i18n';
-import KeymapsModule, { KeymapEvent } from '../keymaps';
-import ModalModule, { ModalEvent } from '../modal_dialog';
+import KeymapsModule from '../keymaps';
+import ModalModule from '../modal_dialog';
 import LayerManager from '../navigator';
 import PageManager from '../pages';
 import PanelManager from '../panels';
 import ParserModule from '../parser';
 import { CustomParserCss } from '../parser/config/config';
-import RichTextEditorModule, { RichTextEditorEvent } from '../rich_text_editor';
+import RichTextEditorModule from '../rich_text_editor';
 import { CustomRTE } from '../rich_text_editor/config/config';
-import SelectorManager, { SelectorEvent } from '../selector_manager';
-import StorageManager, { ProjectData, StorageEvent, StorageOptions } from '../storage_manager';
-import StyleManager, { StyleManagerEvent } from '../style_manager';
+import SelectorManager from '../selector_manager';
+import StorageManager, { ProjectData, StorageOptions } from '../storage_manager';
+import StyleManager from '../style_manager';
 import TraitManager from '../trait_manager';
 import UndoManagerModule from '../undo_manager';
 import UtilsModule from '../utils';
 import html from '../utils/html';
 import defConfig, { EditorConfig, EditorConfigKeys } from './config/config';
 import EditorModel, { EditorLoadOptions } from './model/Editor';
-import { EditorEvents } from './types';
+import {
+  EditorConfigType,
+  EditorEvent,
+  EditorEventCallbacks,
+  EditorEventHandler,
+  EditorEvents,
+  EditorModelParam,
+} from './types';
 import EditorView from './view/EditorView';
 
 export type ParsedRule = {
@@ -89,28 +95,6 @@ export type ParsedRule = {
   atRule?: string;
   params?: string;
 };
-
-type GeneralEvent = 'canvasScroll' | 'undo' | 'redo' | 'load' | 'update';
-
-type EditorBuiltInEvents =
-  | ComponentEvent
-  | BlockEvent
-  | AssetEvent
-  | KeymapEvent
-  | StyleManagerEvent
-  | StorageEvent
-  | CanvasEvent
-  | SelectorEvent
-  | RichTextEditorEvent
-  | ModalEvent
-  | CommandEvent
-  | GeneralEvent;
-
-type EditorEvent = LiteralUnion<EditorBuiltInEvents, string>;
-
-type EditorConfigType = EditorConfig & { pStylePrefix?: string };
-
-type EditorModelParam<T extends keyof EditorModel, N extends number> = Parameters<EditorModel[T]>[N];
 
 export type EditorParam<T extends keyof Editor, N extends number> = Parameters<Editor[T]>[N];
 
@@ -733,8 +717,8 @@ export default class Editor implements IBaseModule<EditorConfig> {
    * @param  {Function} callback Callback function
    * @return {this}
    */
-  on(event: EditorEvent, callback: EventHandler) {
-    this.em.on(event, callback);
+  on<E extends EditorEvent>(event: E, callback: EditorEventHandler<E>) {
+    this.em.on(event as string, callback);
     return this;
   }
 
@@ -744,8 +728,8 @@ export default class Editor implements IBaseModule<EditorConfig> {
    * @param  {Function} callback Callback function
    * @return {this}
    */
-  once(event: EditorEvent, callback: EventHandler) {
-    this.em.once(event, callback);
+  once<E extends EditorEvent>(event: E, callback: EditorEventHandler<E>) {
+    this.em.once(event as string, callback);
     return this;
   }
 
@@ -755,8 +739,8 @@ export default class Editor implements IBaseModule<EditorConfig> {
    * @param  {Function} callback Callback function
    * @return {this}
    */
-  off(event: EditorEvent, callback: EventHandler) {
-    this.em.off(event, callback);
+  off<E extends EditorEvent>(event: E, callback: EditorEventHandler<E>) {
+    this.em.off(event as string, callback);
     return this;
   }
 
@@ -765,8 +749,11 @@ export default class Editor implements IBaseModule<EditorConfig> {
    * @param  {string} event Event to trigger
    * @return {this}
    */
-  trigger(event: EditorEvent, ...args: any[]) {
-    this.em.trigger.apply(this.em, [event, ...args]);
+  trigger<E extends EditorEvent>(
+    event: E,
+    ...args: E extends keyof EditorEventCallbacks ? EditorEventCallbacks[E] : any[]
+  ) {
+    this.em.trigger.apply(this.em, [event as string, ...args]);
     return this;
   }
 

--- a/packages/core/src/editor/model/Editor.ts
+++ b/packages/core/src/editor/model/Editor.ts
@@ -280,7 +280,7 @@ export default class EditorModel extends Model {
     this.on('change:componentHovered', this.componentHovered, this);
     this.on('change:changesCount', this.updateChanges, this);
     this.on('change:readyLoad change:readyCanvas', this._checkReady, this);
-    toLog.forEach((e) => this.listenLog(e));
+    toLog.forEach((e) => this.listenLog(e as keyof typeof logs));
 
     // Deprecations
     [{ from: 'change:selectedComponent', to: 'component:toggled' }].forEach((event) => {
@@ -303,9 +303,12 @@ export default class EditorModel extends Model {
     return this.config.el;
   }
 
-  listenLog(event: string) {
-    //@ts-ignore
-    this.listenTo(this, `log:${event}`, logs[event]);
+  listenLog(event: keyof typeof logs) {
+    this.listenTo(this, `log:${event}`, (...args) => {
+      if (!this.config.log) return;
+      const logFn = logs[event];
+      logFn?.(...args);
+    });
   }
 
   get config() {

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -1,3 +1,48 @@
+import { AssetEvent } from '../asset_manager/types';
+import { BlockEvent } from '../block_manager';
+import { BlocksEventCallback } from '../block_manager/types';
+import { CanvasEvent } from '../canvas';
+import { CommandEvent } from '../commands';
+import { LiteralUnion } from '../common';
+import { ComponentEvent } from '../dom_components';
+import { KeymapEvent } from '../keymaps';
+import { ModalEvent } from '../modal_dialog';
+import { RichTextEditorEvent } from '../rich_text_editor';
+import { SelectorEvent } from '../selector_manager';
+import { StyleManagerEvent } from '../style_manager';
+import { EditorConfig } from './config/config';
+import EditorModel from './model/Editor';
+
+type GeneralEvent = 'canvasScroll' | 'undo' | 'redo' | 'load' | 'update';
+
+type EditorBuiltInEvents =
+  | ComponentEvent
+  | BlockEvent
+  | AssetEvent
+  | KeymapEvent
+  | StyleManagerEvent
+  | StorageEvent
+  | CanvasEvent
+  | SelectorEvent
+  | RichTextEditorEvent
+  | ModalEvent
+  | CommandEvent
+  | GeneralEvent;
+
+export type EditorEvent = LiteralUnion<EditorBuiltInEvents, string>;
+
+export type EditorConfigType = EditorConfig & { pStylePrefix?: string };
+
+export type EditorModelParam<T extends keyof EditorModel, N extends number> = Parameters<EditorModel[T]>[N];
+
+export interface EditorEventCallbacks extends BlocksEventCallback {
+  [key: string]: any[];
+}
+
+export type EditorEventHandler<E extends EditorEvent> = E extends keyof EditorEventCallbacks
+  ? (...args: EditorEventCallbacks[E]) => void
+  : (...args: any[]) => void;
+
 /**{START_EVENTS}*/
 export enum EditorEvents {
   /**

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -4,6 +4,7 @@ import { BlocksEventCallback } from '../block_manager/types';
 import { CanvasEvent } from '../canvas';
 import { CommandEvent } from '../commands';
 import { LiteralUnion } from '../common';
+import { DataSourceEvent, DataSourcesEventCallback } from '../data_sources/types';
 import { ComponentEvent } from '../dom_components';
 import { KeymapEvent } from '../keymaps';
 import { ModalEvent } from '../modal_dialog';
@@ -16,6 +17,7 @@ import EditorModel from './model/Editor';
 type GeneralEvent = 'canvasScroll' | 'undo' | 'redo' | 'load' | 'update';
 
 type EditorBuiltInEvents =
+  | DataSourceEvent
   | ComponentEvent
   | BlockEvent
   | AssetEvent
@@ -35,7 +37,7 @@ export type EditorConfigType = EditorConfig & { pStylePrefix?: string };
 
 export type EditorModelParam<T extends keyof EditorModel, N extends number> = Parameters<EditorModel[T]>[N];
 
-export interface EditorEventCallbacks extends BlocksEventCallback {
+export interface EditorEventCallbacks extends BlocksEventCallback, DataSourcesEventCallback {
   [key: string]: any[];
 }
 

--- a/packages/core/src/keymaps/types.ts
+++ b/packages/core/src/keymaps/types.ts
@@ -1,0 +1,28 @@
+/**{START_EVENTS}*/
+export enum KeymapsEvents {
+  /**
+   * @event `keymap:add` New keymap added. The new keymap object is passed as an argument to the callback.
+   * @example
+   * editor.on('keymap:add', (keymap) => { ... });
+   */
+  add = 'keymap:add',
+
+  /**
+   * @event `keymap:remove` Keymap removed. The removed keymap object is passed as an argument to the callback.
+   * @example
+   * editor.on('keymap:remove', (keymap) => { ... });
+   */
+  remove = 'keymap:remove',
+
+  /**
+   * @event `keymap:emit` Some keymap emitted. The keymapId, shortcutUsed, and Event are passed as arguments to the callback.
+   * @example
+   * editor.on('keymap:emit', (keymapId, shortcutUsed, event) => { ... });
+   */
+  emit = 'keymap:emit',
+  emitId = 'keymap:emit:',
+}
+/**{END_EVENTS}*/
+
+// need this to avoid the TS documentation generator to break
+export default KeymapsEvents;

--- a/packages/core/src/modal_dialog/index.ts
+++ b/packages/core/src/modal_dialog/index.ts
@@ -14,10 +14,7 @@
  * const modal = editor.Modal;
  * ```
  *
- * ## Available Events
- * * `modal:open` - Modal is opened
- * * `modal:close` - Modal is closed
- * * `modal` - Event triggered on any change related to the modal. An object containing all the available data about the triggered event is passed as an argument to the callback.
+ * {REPLACE_EVENTS}
  *
  * ## Methods
  * * [open](#open)
@@ -35,18 +32,20 @@
 
 import { debounce, isFunction, isString } from 'underscore';
 import { Module } from '../abstract';
-import EditorView from '../editor/view/EditorView';
+import { EventHandler } from '../common';
 import EditorModel from '../editor/model/Editor';
+import EditorView from '../editor/view/EditorView';
 import { createText } from '../utils/dom';
 import defConfig, { ModalConfig } from './config/config';
 import ModalM from './model/Modal';
+import { ModalEvents } from './types';
 import ModalView from './view/ModalView';
-import { EventHandler } from '../common';
 
-export type ModalEvent = 'modal:open' | 'modal:close' | 'modal';
+export type ModalEvent = `${ModalEvents}`;
 
 export default class ModalModule extends Module<ModalConfig> {
   modal?: ModalView;
+  events = ModalEvents;
 
   /**
    * Initialize module. Automatically called with a new instance of the editor
@@ -55,10 +54,10 @@ export default class ModalModule extends Module<ModalConfig> {
    */
   constructor(em: EditorModel) {
     super(em, 'Modal', defConfig());
-
+    const { events } = this;
     this.model = new ModalM(this);
     this.model.on('change:open', (m: ModalM, enable: boolean) => {
-      em.trigger(`modal:${enable ? 'open' : 'close'}`);
+      em.trigger(enable ? events.open : events.close);
     });
     this.model.on(
       'change',
@@ -67,7 +66,7 @@ export default class ModalModule extends Module<ModalConfig> {
         const { custom } = this.config;
         //@ts-ignore
         isFunction(custom) && custom(data);
-        em.trigger('modal', data);
+        em.trigger(events.all, data);
       }, 0),
     );
 
@@ -142,7 +141,8 @@ export default class ModalModule extends Module<ModalConfig> {
    * });
    */
   onceClose(clb: EventHandler) {
-    this.em.once('modal:close', clb);
+    const { em, events } = this;
+    em.once(events.close, clb);
     return this;
   }
 
@@ -157,7 +157,8 @@ export default class ModalModule extends Module<ModalConfig> {
    * });
    */
   onceOpen(clb: EventHandler) {
-    this.em.once('modal:open', clb);
+    const { em, events } = this;
+    em.once(events.open, clb);
     return this;
   }
 

--- a/packages/core/src/modal_dialog/types.ts
+++ b/packages/core/src/modal_dialog/types.ts
@@ -1,0 +1,27 @@
+/**{START_EVENTS}*/
+export enum ModalEvents {
+  /**
+   * @event `modal:open` Modal is opened
+   * @example
+   * editor.on('modal:open', () => { ... });
+   */
+  open = 'modal:open',
+
+  /**
+   * @event `modal:close` Modal is closed
+   * @example
+   * editor.on('modal:close', () => { ... });
+   */
+  close = 'modal:close',
+
+  /**
+   * @event `modal` Event triggered on any change related to the modal. An object containing all the available data about the triggered event is passed as an argument to the callback.
+   * @example
+   * editor.on('modal', ({ open, title, content, ... }) => { ... });
+   */
+  all = 'modal',
+}
+/**{END_EVENTS}*/
+
+// need this to avoid the TS documentation generator to break
+export default ModalEvents;

--- a/packages/core/src/navigator/index.ts
+++ b/packages/core/src/navigator/index.ts
@@ -15,9 +15,7 @@
  * const layers = editor.Layers;
  * ```
  *
- * ## Available Events
- * * `layer:root` - Root layer changed. The new root component is passed as an argument to the callback.
- * * `layer:component` - Component layer is updated. The updated component is passed as an argument to the callback.
+ * {REPLACE_EVENTS}
  *
  * ## Methods
  * * [setRoot](#setroot)
@@ -39,38 +37,18 @@
  * @module Layers
  */
 
-import { isString, bindAll } from 'underscore';
+import { bindAll, isString } from 'underscore';
 import { ModuleModel } from '../abstract';
 import Module from '../abstract/Module';
 import Component from '../dom_components/model/Component';
+import { ComponentsEvents } from '../dom_components/types';
 import EditorModel from '../editor/model/Editor';
 import { hasWin, isComponent, isDef } from '../utils/mixins';
 import defConfig, { LayerManagerConfig } from './config/config';
+import { LayerData, LayerEvents } from './types';
 import View from './view/ItemView';
-import { ComponentsEvents } from '../dom_components/types';
 
-interface LayerData {
-  name: string;
-  open: boolean;
-  selected: boolean;
-  hovered: boolean;
-  visible: boolean;
-  locked: boolean;
-  components: Component[];
-}
-
-export const evAll = 'layer';
-export const evPfx = `${evAll}:`;
-export const evRoot = `${evPfx}root`;
-export const evComponent = `${evPfx}component`;
-export const evCustom = `${evPfx}custom`;
-
-const events = {
-  all: evAll,
-  root: evRoot,
-  component: evComponent,
-  custom: evCustom,
-};
+export type LayerEvent = `${LayerEvents}`;
 
 const styleOpts = { mediaText: '' };
 
@@ -88,7 +66,7 @@ export default class LayerManager extends Module<LayerManagerConfig> {
 
   view?: View;
 
-  events = events;
+  events = LayerEvents;
 
   constructor(em: EditorModel) {
     super(em, 'LayerManager', defConfig());
@@ -358,9 +336,10 @@ export default class LayerManager extends Module<LayerManagerConfig> {
   }
 
   __onRootChange() {
+    const { em, events } = this;
     const root = this.getRoot();
     this.view?.setRoot(root);
-    this.em.trigger(evRoot, root);
+    em.trigger(events.root, root);
     this.__trgCustom();
   }
 
@@ -390,6 +369,7 @@ export default class LayerManager extends Module<LayerManagerConfig> {
   }
 
   updateLayer(component: Component, opts?: any) {
-    this.em.trigger(evComponent, component, opts);
+    const { em, events } = this;
+    em.trigger(events.component, component, opts);
   }
 }

--- a/packages/core/src/navigator/index.ts
+++ b/packages/core/src/navigator/index.ts
@@ -9,7 +9,7 @@
  * })
  * ```
  *
- * Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance
+ * Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
  *
  * ```js
  * const layers = editor.Layers;

--- a/packages/core/src/navigator/types.ts
+++ b/packages/core/src/navigator/types.ts
@@ -1,0 +1,39 @@
+import Component from '../dom_components/model/Component';
+
+export interface LayerData {
+  name: string;
+  open: boolean;
+  selected: boolean;
+  hovered: boolean;
+  visible: boolean;
+  locked: boolean;
+  components: Component[];
+}
+
+/**{START_EVENTS}*/
+export enum LayerEvents {
+  /**
+   * @event `layer:root` Root layer changed. The new root component is passed as an argument to the callback.
+   * @example
+   * editor.on('layer:root', (component) => { ... });
+   */
+  root = 'layer:root',
+
+  /**
+   * @event `layer:component` Component layer is updated. The updated component is passed as an argument to the callback.
+   * @example
+   * editor.on('layer:component', (component, opts) => { ... });
+   */
+  component = 'layer:component',
+
+  /**
+   * @event `layer:custom` Custom layer event. Object with container and root is passed as an argument to the callback.
+   * @example
+   * editor.on('layer:custom', ({ container, root }) => { ... });
+   */
+  custom = 'layer:custom',
+}
+/**{END_EVENTS}*/
+
+// need this to avoid the TS documentation generator to break
+export default LayerEvents;

--- a/packages/core/src/rich_text_editor/types.ts
+++ b/packages/core/src/rich_text_editor/types.ts
@@ -1,0 +1,39 @@
+import ComponentTextView from '../dom_components/view/ComponentTextView';
+
+export interface ModelRTE {
+  currentView?: ComponentTextView;
+}
+
+export type RichTextEditorEvent = `${RichTextEditorEvents}`;
+
+export interface RteDisableResult {
+  forceSync?: boolean;
+}
+
+/**{START_EVENTS}*/
+export enum RichTextEditorEvents {
+  /**
+   * @event `rte:enable` RTE enabled. The view, on which RTE is enabled, and the RTE instance are passed as arguments.
+   * @example
+   * editor.on('rte:enable', (view, rte) => { ... });
+   */
+  enable = 'rte:enable',
+
+  /**
+   * @event `rte:disable` RTE disabled. The view, on which RTE is disabled, and the RTE instance are passed as arguments.
+   * @example
+   * editor.on('rte:disable', (view, rte) => { ... });
+   */
+  disable = 'rte:disable',
+
+  /**
+   * @event `rte:custom` Custom RTE event. Object with enabled status, container, and actions is passed as an argument.
+   * @example
+   * editor.on('rte:custom', ({ enabled, container, actions }) => { ... });
+   */
+  custom = 'rte:custom',
+}
+/**{END_EVENTS}*/
+
+// need this to avoid the TS documentation generator to break
+export default RichTextEditorEvents;

--- a/packages/core/src/selector_manager/index.ts
+++ b/packages/core/src/selector_manager/index.ts
@@ -29,23 +29,13 @@
  * })
  * ```
  *
- * Once the editor is instantiated you can use its API and listen to its events. Before using these methods, you should get the module from the instance.
+ * Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
  *
  * ```js
- * // Listen to events
- * editor.on('selector:add', (selector) => { ... });
- *
- * // Use the API
  * const sm = editor.Selectors;
- * sm.add(...);
  * ```
  *
- * ## Available Events
- * * `selector:add` - Selector added. The [Selector] is passed as an argument to the callback.
- * * `selector:remove` - Selector removed. The [Selector] is passed as an argument to the callback.
- * * `selector:update` - Selector updated. The [Selector] and the object containing changes are passed as arguments to the callback.
- * * `selector:state` - States changed. An object containing all the available data about the triggered event is passed as an argument to the callback.
- * * `selector` - Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback.
+ * {REPLACE_EVENTS}
  *
  * ## Methods
  * * [getConfig](#getconfig)
@@ -73,46 +63,26 @@
  * @module Selectors
  */
 
-import { isString, debounce, isObject, isArray, bindAll } from 'underscore';
+import { bindAll, debounce, isArray, isObject, isString } from 'underscore';
+import { ItemManagerModule } from '../abstract/Module';
+import { Collection, Debounced, Model, RemoveOptions, SetOptions } from '../common';
+import Component from '../dom_components/model/Component';
+import { ComponentsEvents } from '../dom_components/types';
+import StyleableModel from '../domain_abstract/model/StyleableModel';
+import EditorModel from '../editor/model/Editor';
+import { StyleModuleParam } from '../style_manager';
 import { isComponent, isRule } from '../utils/mixins';
-import { Model, Collection, RemoveOptions, SetOptions, Debounced } from '../common';
 import defConfig, { SelectorManagerConfig } from './config/config';
 import Selector from './model/Selector';
 import Selectors from './model/Selectors';
 import State from './model/State';
+import { SelectorEvents, SelectorStringObject } from './types';
 import ClassTagsView from './view/ClassTagsView';
-import EditorModel from '../editor/model/Editor';
-import Component from '../dom_components/model/Component';
-import { ItemManagerModule } from '../abstract/Module';
-import { StyleModuleParam } from '../style_manager';
-import StyleableModel from '../domain_abstract/model/StyleableModel';
-import { ComponentsEvents } from '../dom_components/types';
 
-export type SelectorEvent = 'selector:add' | 'selector:remove' | 'selector:update' | 'selector:state' | 'selector';
+export type { SelectorEvent } from './types';
 
 const isId = (str: string) => isString(str) && str[0] == '#';
 const isClass = (str: string) => isString(str) && str[0] == '.';
-
-export const evAll = 'selector';
-export const evPfx = `${evAll}:`;
-export const evAdd = `${evPfx}add`;
-export const evUpdate = `${evPfx}update`;
-export const evRemove = `${evPfx}remove`;
-export const evRemoveBefore = `${evRemove}:before`;
-export const evCustom = `${evPfx}custom`;
-export const evState = `${evPfx}state`;
-
-const selectorEvents = {
-  all: evAll,
-  update: evUpdate,
-  add: evAdd,
-  remove: evRemove,
-  removeBefore: evRemoveBefore,
-  state: evState,
-  custom: evCustom,
-};
-
-type SelectorStringObject = string | { name?: string; label?: string; type?: number };
 
 export default class SelectorManager extends ItemManagerModule<SelectorManagerConfig & { pStylePrefix?: string }> {
   Selector = Selector;
@@ -124,7 +94,7 @@ export default class SelectorManager extends ItemManagerModule<SelectorManagerCo
   selectorTags?: ClassTagsView;
   selected: Selectors;
   all: Selectors;
-  events!: typeof selectorEvents;
+  events = SelectorEvents;
   storageKey = '';
   __update: Debounced;
   __ctn?: HTMLElement;
@@ -137,9 +107,9 @@ export default class SelectorManager extends ItemManagerModule<SelectorManagerCo
    */
 
   constructor(em: EditorModel) {
-    super(em, 'SelectorManager', new Selectors([]), selectorEvents, defConfig(), { skipListen: true });
+    super(em, 'SelectorManager', new Selectors([]), SelectorEvents, defConfig(), { skipListen: true });
     bindAll(this, '__updateSelectedByComponents');
-    const { config } = this;
+    const { config, events } = this;
     const ppfx = config.pStylePrefix;
     if (ppfx) config.stylePrefix = ppfx + config.stylePrefix;
 
@@ -154,9 +124,9 @@ export default class SelectorManager extends ItemManagerModule<SelectorManagerCo
     this.__update = debounce(() => this.__trgCustom(), 0);
     this.__initListen({
       collections: [this.states, this.selected],
-      propagate: [{ entity: this.states, event: this.events.state }],
+      propagate: [{ entity: this.states, event: events.state }],
     });
-    em.on('change:state', (m, value) => em.trigger(evState, value));
+    em.on('change:state', (m, value) => em.trigger(events.state, value));
     this.model.on('change:cFirst', (m, value) => em.trigger('selector:type', value));
     const eventCmpUpdateCls = `${ComponentsEvents.update}:classes`;
     em.on(`component:toggled ${eventCmpUpdateCls}`, this.__updateSelectedByComponents);

--- a/packages/core/src/selector_manager/index.ts
+++ b/packages/core/src/selector_manager/index.ts
@@ -79,7 +79,7 @@ import State from './model/State';
 import { SelectorEvents, SelectorStringObject } from './types';
 import ClassTagsView from './view/ClassTagsView';
 
-export type { SelectorEvent } from './types';
+export type SelectorEvent = `${SelectorEvents}`;
 
 const isId = (str: string) => isString(str) && str[0] == '#';
 const isClass = (str: string) => isString(str) && str[0] == '.';

--- a/packages/core/src/selector_manager/types.ts
+++ b/packages/core/src/selector_manager/types.ts
@@ -51,8 +51,6 @@ export enum SelectorEvents {
 }
 /**{END_EVENTS}*/
 
-export type SelectorEvent = `${SelectorEvents}`;
-
 export type SelectorStringObject = string | { name?: string; label?: string; type?: number };
 
 // need this to avoid the TS documentation generator to break

--- a/packages/core/src/selector_manager/types.ts
+++ b/packages/core/src/selector_manager/types.ts
@@ -1,0 +1,59 @@
+/**{START_EVENTS}*/
+export enum SelectorEvents {
+  /**
+   * @event `selector:add` Selector added. The Selector is passed as an argument to the callback.
+   * @example
+   * editor.on('selector:add', (selector) => { ... });
+   */
+  add = 'selector:add',
+
+  /**
+   * @event `selector:remove` Selector removed. The Selector is passed as an argument to the callback.
+   * @example
+   * editor.on('selector:remove', (selector) => { ... });
+   */
+  remove = 'selector:remove',
+
+  /**
+   * @event `selector:remove:before` Before selector remove. The Selector is passed as an argument to the callback.
+   * @example
+   * editor.on('selector:remove:before', (selector) => { ... });
+   */
+  removeBefore = 'selector:remove:before',
+
+  /**
+   * @event `selector:update` Selector updated. The Selector and the object containing changes are passed as arguments to the callback.
+   * @example
+   * editor.on('selector:update', (selector, changes) => { ... });
+   */
+  update = 'selector:update',
+
+  /**
+   * @event `selector:state` States changed. An object containing all the available data about the triggered event is passed as an argument to the callback.
+   * @example
+   * editor.on('selector:state', (state) => { ... });
+   */
+  state = 'selector:state',
+
+  /**
+   * @event `selector:custom` Custom selector event. An object containing states, selected selectors, and container is passed as an argument.
+   * @example
+   * editor.on('selector:custom', ({ states, selected, container }) => { ... });
+   */
+  custom = 'selector:custom',
+
+  /**
+   * @event `selector` Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback.
+   * @example
+   * editor.on('selector', ({ event, selector, changes, ... }) => { ... });
+   */
+  all = 'selector',
+}
+/**{END_EVENTS}*/
+
+export type SelectorEvent = `${SelectorEvents}`;
+
+export type SelectorStringObject = string | { name?: string; label?: string; type?: number };
+
+// need this to avoid the TS documentation generator to break
+export default SelectorEvents;

--- a/packages/core/src/style_manager/index.ts
+++ b/packages/core/src/style_manager/index.ts
@@ -68,7 +68,9 @@ import { PropertyTypes, StyleManagerEvents, StyleTarget } from './types';
 import { CustomPropertyView } from './view/PropertyView';
 import SectorsView from './view/SectorsView';
 
-export type { PropertyTypes, StyleManagerEvent, StyleModuleParam, StyleTarget } from './types';
+export type { PropertyTypes, StyleModuleParam, StyleTarget } from './types';
+
+export type StyleManagerEvent = `${StyleManagerEvents}`;
 
 const propDef = (value: any) => value || value === 0;
 

--- a/packages/core/src/style_manager/index.ts
+++ b/packages/core/src/style_manager/index.ts
@@ -9,29 +9,13 @@
  * })
  * ```
  *
- * Once the editor is instantiated you can use its API and listen to its events. Before using these methods, you should get the module from the instance.
+ * Once the editor is instantiated you can use its API. Before using these methods you should get the module from the instance.
  *
  * ```js
- * // Listen to events
- * editor.on('style:sector:add', (sector) => { ... });
- *
- * // Use the API
  * const styleManager = editor.StyleManager;
- * styleManager.addSector(...);
  * ```
- * ## Available Events
- * * `style:sector:add` - Sector added. The [Sector] is passed as an argument to the callback.
- * * `style:sector:remove` - Sector removed. The [Sector] is passed as an argument to the callback.
- * * `style:sector:update` - Sector updated. The [Sector] and the object containing changes are passed as arguments to the callback.
- * * `style:property:add` - Property added. The [Property] is passed as an argument to the callback.
- * * `style:property:remove` - Property removed. The [Property] is passed as an argument to the callback.
- * * `style:property:update` - Property updated. The [Property] and the object containing changes are passed as arguments to the callback.
- * * `style:target` - Target selection changed. The target (or `null` in case the target is deselected) is passed as an argument to the callback.
- * <!--
- * * `styleManager:update:target` - The target (Component or CSSRule) is changed
- * * `styleManager:change` - Triggered on style property change from new selected component, the view of the property is passed as an argument to the callback
- * * `styleManager:change:{propertyName}` - As above but for a specific style property
- * -->
+ *
+ * {REPLACE_EVENTS}
  *
  * ## Methods
  * * [getConfig](#getconfig)
@@ -63,71 +47,30 @@
  * @module docsjs.StyleManager
  */
 
-import { isUndefined, isArray, isString, debounce, bindAll } from 'underscore';
-import { isComponent } from '../utils/mixins';
+import { bindAll, debounce, isArray, isString, isUndefined } from 'underscore';
+import { ItemManagerModule } from '../abstract/Module';
 import { AddOptions, Debounced, Model } from '../common';
+import CssRule from '../css_composer/model/CssRule';
+import Component from '../dom_components/model/Component';
+import { ComponentsEvents } from '../dom_components/types';
+import StyleableModel, { StyleProps } from '../domain_abstract/model/StyleableModel';
+import EditorModel from '../editor/model/Editor';
+import { isComponent } from '../utils/mixins';
 import defConfig, { StyleManagerConfig } from './config/config';
+import Properties from './model/Properties';
+import Property, { PropertyProps } from './model/Property';
+import PropertyComposite from './model/PropertyComposite';
+import PropertyFactory from './model/PropertyFactory';
+import PropertyStack from './model/PropertyStack';
 import Sector, { SectorProperties } from './model/Sector';
 import Sectors from './model/Sectors';
-import Properties from './model/Properties';
-import PropertyFactory from './model/PropertyFactory';
-import SectorsView from './view/SectorsView';
-import { ItemManagerModule } from '../abstract/Module';
-import EditorModel from '../editor/model/Editor';
-import Property, { PropertyProps } from './model/Property';
-import Component from '../dom_components/model/Component';
-import CssRule from '../css_composer/model/CssRule';
-import StyleableModel, { StyleProps } from '../domain_abstract/model/StyleableModel';
+import { PropertyTypes, StyleManagerEvents, StyleTarget } from './types';
 import { CustomPropertyView } from './view/PropertyView';
-import { PropertySelectProps } from './model/PropertySelect';
-import { PropertyNumberProps } from './model/PropertyNumber';
-import PropertyStack, { PropertyStackProps } from './model/PropertyStack';
-import PropertyComposite from './model/PropertyComposite';
-import { ComponentsEvents } from '../dom_components/types';
+import SectorsView from './view/SectorsView';
 
-export type PropertyTypes = PropertyStackProps | PropertySelectProps | PropertyNumberProps;
-
-export type StyleManagerEvent =
-  | 'style:sector:add'
-  | 'style:sector:remove'
-  | 'style:sector:update'
-  | 'style:property:add'
-  | 'style:property:remove'
-  | 'style:property:update'
-  | 'style:target';
-
-export type StyleTarget = StyleableModel;
-
-export const evAll = 'style';
-export const evPfx = `${evAll}:`;
-export const evSector = `${evPfx}sector`;
-export const evSectorAdd = `${evSector}:add`;
-export const evSectorRemove = `${evSector}:remove`;
-export const evSectorUpdate = `${evSector}:update`;
-export const evProp = `${evPfx}property`;
-export const evPropAdd = `${evProp}:add`;
-export const evPropRemove = `${evProp}:remove`;
-export const evPropUp = `${evProp}:update`;
-export const evLayerSelect = `${evPfx}layer:select`;
-export const evTarget = `${evPfx}target`;
-export const evCustom = `${evPfx}custom`;
-
-export type StyleModuleParam<T extends keyof StyleManager, N extends number> = Parameters<StyleManager[T]>[N];
+export type { PropertyTypes, StyleManagerEvent, StyleModuleParam, StyleTarget } from './types';
 
 const propDef = (value: any) => value || value === 0;
-
-const stylesEvents = {
-  all: evAll,
-  sectorAdd: evSectorAdd,
-  sectorRemove: evSectorRemove,
-  sectorUpdate: evSectorUpdate,
-  propertyAdd: evPropAdd,
-  propertyRemove: evPropRemove,
-  propertyUpdate: evPropUp,
-  layerSelect: evLayerSelect,
-  target: evTarget,
-  custom: evCustom,
-};
 
 export default class StyleManager extends ItemManagerModule<
   StyleManagerConfig,
@@ -137,7 +80,7 @@ export default class StyleManager extends ItemManagerModule<
   builtIn: PropertyFactory;
   upAll: Debounced;
   properties: typeof Properties;
-  events!: typeof stylesEvents;
+  events = StyleManagerEvents;
   sectors: Sectors;
   SectView!: SectorsView;
   Sector = Sector;
@@ -157,8 +100,9 @@ export default class StyleManager extends ItemManagerModule<
    * @private
    */
   constructor(em: EditorModel) {
-    super(em, 'StyleManager', new Sectors([], { em }), stylesEvents, defConfig());
+    super(em, 'StyleManager', new Sectors([], { em }), StyleManagerEvents, defConfig());
     bindAll(this, '__clearStateTarget');
+    const { events } = this;
     const c = this.config;
     const ppfx = c.pStylePrefix;
     if (ppfx) c.stylePrefix = ppfx + c.stylePrefix;
@@ -185,10 +129,10 @@ export default class StyleManager extends ItemManagerModule<
 
     // Triggers only custom event
     const trgCustom = debounce(() => this.__trgCustom(), 0);
-    model.listenTo(em, `${evLayerSelect} ${evTarget}`, trgCustom);
+    model.listenTo(em, `${events.layerSelect} ${events.target}`, trgCustom);
 
     // Other listeners
-    model.on('change:lastTarget', () => em.trigger(evTarget, this.getSelected()));
+    model.on('change:lastTarget', () => em.trigger(events.target, this.getSelected()));
   }
 
   __upSel() {

--- a/packages/core/src/style_manager/types.ts
+++ b/packages/core/src/style_manager/types.ts
@@ -1,0 +1,90 @@
+import StyleManager from '.';
+import StyleableModel from '../domain_abstract/model/StyleableModel';
+import { PropertyNumberProps } from './model/PropertyNumber';
+import { PropertySelectProps } from './model/PropertySelect';
+import { PropertyStackProps } from './model/PropertyStack';
+
+export type PropertyTypes = PropertyStackProps | PropertySelectProps | PropertyNumberProps;
+
+export type StyleTarget = StyleableModel;
+
+export type StyleModuleParam<T extends keyof StyleManager, N extends number> = Parameters<StyleManager[T]>[N];
+
+/**{START_EVENTS}*/
+export enum StyleManagerEvents {
+  /**
+   * @event `style:sector:add` Sector added. The Sector is passed as an argument to the callback.
+   * @example
+   * editor.on('style:sector:add', (sector) => { ... });
+   */
+  sectorAdd = 'style:sector:add',
+
+  /**
+   * @event `style:sector:remove` Sector removed. The Sector is passed as an argument to the callback.
+   * @example
+   * editor.on('style:sector:remove', (sector) => { ... });
+   */
+  sectorRemove = 'style:sector:remove',
+
+  /**
+   * @event `style:sector:update` Sector updated. The Sector and the object containing changes are passed as arguments to the callback.
+   * @example
+   * editor.on('style:sector:update', (sector, changes) => { ... });
+   */
+  sectorUpdate = 'style:sector:update',
+
+  /**
+   * @event `style:property:add` Property added. The Property is passed as an argument to the callback.
+   * @example
+   * editor.on('style:property:add', (property) => { ... });
+   */
+  propertyAdd = 'style:property:add',
+
+  /**
+   * @event `style:property:remove` Property removed. The Property is passed as an argument to the callback.
+   * @example
+   * editor.on('style:property:remove', (property) => { ... });
+   */
+  propertyRemove = 'style:property:remove',
+
+  /**
+   * @event `style:property:update` Property updated. The Property and the object containing changes are passed as arguments to the callback.
+   * @example
+   * editor.on('style:property:update', (property, changes) => { ... });
+   */
+  propertyUpdate = 'style:property:update',
+
+  /**
+   * @event `style:target` Target selection changed. The target (or null in case the target is deselected) is passed as an argument to the callback.
+   * @example
+   * editor.on('style:target', (target) => { ... });
+   */
+  target = 'style:target',
+
+  /**
+   * @event `style:layer:select` Layer selected. Object containing layer data is passed as an argument.
+   * @example
+   * editor.on('style:layer:select', (data) => { ... });
+   */
+  layerSelect = 'style:layer:select',
+
+  /**
+   * @event `style:custom` Custom style event. Object containing all custom data is passed as an argument.
+   * @example
+   * editor.on('style:custom', ({ container }) => { ... });
+   */
+  custom = 'style:custom',
+
+  /**
+   * @event `style` Catch-all event for all the events mentioned above. An object containing all the available data about the triggered event is passed as an argument to the callback.
+   * @example
+   * editor.on('style', ({ event, sector, property, ... }) => { ... });
+   */
+  all = 'style',
+}
+/**{END_EVENTS}*/
+
+export type StyleManagerEvent = `${StyleManagerEvents}`;
+
+// need this to avoid the TS documentation generator to break
+export default StyleManagerEvents;

--- a/packages/core/src/style_manager/types.ts
+++ b/packages/core/src/style_manager/types.ts
@@ -84,7 +84,5 @@ export enum StyleManagerEvents {
 }
 /**{END_EVENTS}*/
 
-export type StyleManagerEvent = `${StyleManagerEvents}`;
-
 // need this to avoid the TS documentation generator to break
 export default StyleManagerEvents;

--- a/packages/core/src/utils/mixins.ts
+++ b/packages/core/src/utils/mixins.ts
@@ -25,7 +25,7 @@ function castPath(value: string | string[], object: ObjectAny) {
   return object.hasOwnProperty(value) ? [value] : stringToPath(value);
 }
 
-export const get = (object: ObjectAny, path: string | string[], def: any) => {
+export const get = (object: ObjectAny, path: string | string[], def?: any) => {
   const paths = castPath(path, object);
   const length = paths.length;
   let index = 0;
@@ -40,22 +40,32 @@ export const set = (object: ObjectAny, path: string | string[], value: any): boo
   if (!isObject(object)) return false;
   const paths = castPath(path, object);
   const length = paths.length;
-  const lastIndex = length - 1;
-  let index = -1;
-  let nested = object;
 
-  while (nested != null && ++index < length) {
-    const key = paths[index];
-    let newValue = value;
+  if (length === 0) return false;
 
-    if (index != lastIndex) {
-      const objValue = nested[key];
-      newValue = isObject(objValue) ? objValue : !isNaN(+paths[index + 1]) ? [] : {};
-    }
-    nested[key] = newValue;
-    nested = nested[key];
+  if (length === 1) {
+    object[paths[0]] = value;
+    return true;
   }
-  return true;
+
+  const parentPath = paths.slice(0, -1);
+  const lastKey = paths[length - 1];
+  const parent = get(object, parentPath);
+
+  if (parent) {
+    if (Array.isArray(parent)) {
+      const index = +lastKey;
+      if (!isNaN(index)) {
+        parent[index] = value;
+        return true;
+      }
+    } else if (isObject(parent)) {
+      (parent as ObjectAny)[lastKey] = value;
+      return true;
+    }
+  }
+
+  return false;
 };
 
 export const serialize = (obj: ObjectAny) => JSON.parse(JSON.stringify(obj));

--- a/packages/core/src/utils/mixins.ts
+++ b/packages/core/src/utils/mixins.ts
@@ -36,6 +36,28 @@ export const get = (object: ObjectAny, path: string | string[], def: any) => {
   return (index && index == length ? object : undefined) ?? def;
 };
 
+export const set = (object: ObjectAny, path: string | string[], value: any): boolean => {
+  if (!isObject(object)) return false;
+  const paths = castPath(path, object);
+  const length = paths.length;
+  const lastIndex = length - 1;
+  let index = -1;
+  let nested = object;
+
+  while (nested != null && ++index < length) {
+    const key = paths[index];
+    let newValue = value;
+
+    if (index != lastIndex) {
+      const objValue = nested[key];
+      newValue = isObject(objValue) ? objValue : !isNaN(+paths[index + 1]) ? [] : {};
+    }
+    nested[key] = newValue;
+    nested = nested[key];
+  }
+  return true;
+};
+
 export const serialize = (obj: ObjectAny) => JSON.parse(JSON.stringify(obj));
 
 export const isBultInMethod = (key: string) => isFunction(obj[key]);

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -70,14 +70,17 @@ describe('DataSourceManager', () => {
     test('getValue with nested values', () => {
       const ds = addDataSource();
       const address = { city: 'CityName' };
+      const roles = ['admin', 'user'];
       ds.addRecord({
         id: 'id4',
         name: 'Name4',
-        metadata: { address },
+        metadata: { address, roles },
       });
 
       expect(dsm.getValue(`ds1.id4.metadata.address`)).toEqual(address);
       expect(dsm.getValue(`ds1.id4.metadata.address.city`)).toEqual(address.city);
+      expect(dsm.getValue(`ds1.id4.metadata.roles`)).toEqual(roles);
+      expect(dsm.getValue(`ds1.id4.metadata.roles[1]`)).toEqual(roles[1]);
     });
   });
 

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -55,7 +55,7 @@ describe('DataSourceManager', () => {
   });
 
   describe('getValue', () => {
-    test('getValue', () => {
+    test('get value from records', () => {
       const ds = addDataSource();
       const testPath = ds.getRecord('id2')?.getPath('name') || '';
       expect(dsm.getValue(testPath)).toBe('Name2');
@@ -67,7 +67,7 @@ describe('DataSourceManager', () => {
       expect(dsm.getValue('non-existing-ds.id1.name')).toBeUndefined();
     });
 
-    test('getValue with nested values', () => {
+    test('with nested values', () => {
       const ds = addDataSource();
       const address = { city: 'CityName' };
       const roles = ['admin', 'user'];
@@ -85,7 +85,7 @@ describe('DataSourceManager', () => {
   });
 
   describe('setValue', () => {
-    test('Should set value in existing record', () => {
+    test('set value in existing record', () => {
       addDataSource();
       expect(dsm.setValue('ds1.id1.name', 'Name1 Up')).toBe(true);
       expect(dsm.getValue('ds1.id1.name')).toBe('Name1 Up');
@@ -95,6 +95,41 @@ describe('DataSourceManager', () => {
       expect(dsm.setValue('non-existing-ds.id1.name', 'New Name')).toBe(false);
 
       expect(dsm.setValue('invalid-path', 'New Name')).toBe(false);
+    });
+
+    test('set nested values', () => {
+      const ds = addDataSource();
+      const address = { city: 'CityName' };
+      const roles = ['admin', 'user'];
+      ds.addRecord({
+        id: 'id4',
+        name: 'Name4',
+        metadata: { address, roles },
+      });
+
+      // Update nested object property
+      expect(dsm.setValue('ds1.id4.metadata.address.city', 'NewCity')).toBe(true);
+      expect(dsm.getValue('ds1.id4.metadata.address.city')).toBe('NewCity');
+
+      // Update array item
+      expect(dsm.setValue('ds1.id4.metadata.roles[1]', 'editor')).toBe(true);
+      expect(dsm.getValue('ds1.id4.metadata.roles[1]')).toBe('editor');
+
+      // Set entirely new nested object
+      const newAddress = { city: 'AnotherCity', country: 'SomeCountry' };
+      expect(dsm.setValue('ds1.id4.metadata.address', newAddress)).toBe(true);
+      expect(dsm.getValue('ds1.id4.metadata.address')).toEqual(newAddress);
+
+      // Set new array
+      const newRoles = ['editor', 'viewer'];
+      expect(dsm.setValue('ds1.id4.metadata.roles', newRoles)).toBe(true);
+      expect(dsm.getValue('ds1.id4.metadata.roles')).toEqual(newRoles);
+
+      // Set completely new nested structure
+      const newMetadata = { tags: ['tag1', 'tag2'], settings: { theme: 'dark' } };
+      expect(dsm.setValue('ds1.id4.metadata', newMetadata)).toBe(true);
+      expect(dsm.getValue('ds1.id4.metadata')).toEqual(newMetadata);
+      expect(dsm.getValue('ds1.id4.metadata.settings.theme')).toBe('dark');
     });
   });
 });

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -113,7 +113,10 @@ describe('DataSourceManager', () => {
 
       // Update array item
       expect(dsm.setValue('ds1.id4.metadata.roles[1]', 'editor')).toBe(true);
-      expect(dsm.getValue('ds1.id4.metadata.roles[1]')).toBe('editor');
+      expect(dsm.getValue('ds1.id4.metadata')).toEqual({
+        address: { city: 'NewCity' },
+        roles: ['admin', 'editor'],
+      });
 
       // Set entirely new nested object
       const newAddress = { city: 'AnotherCity', country: 'SomeCountry' };

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -57,11 +57,12 @@ describe('DataSourceManager', () => {
   test('getValue', () => {
     const ds = addDataSource();
     const testPath = ds.getRecord('id2')?.getPath('name') || '';
-    expect(dsm.getValue(`${ds.id}.id1.name`)).toBe('Name1');
     expect(dsm.getValue(testPath)).toBe('Name2');
-    expect(dsm.getValue(`${ds.id}.non-existing.name`)).toBeUndefined();
-    expect(dsm.getValue(`${ds.id}.non-existing.name`, 'Default name')).toBe('Default name');
-    expect(dsm.getValue(`${ds.id}.id1.nonExisting`)).toBeUndefined();
+    expect(dsm.getValue(`ds1.id1.name`)).toBe('Name1');
+    expect(dsm.getValue(`ds1[id1]name`)).toBe('Name1');
+    expect(dsm.getValue(`ds1.non-existing.name`)).toBeUndefined();
+    expect(dsm.getValue(`ds1.non-existing.name`, 'Default name')).toBe('Default name');
+    expect(dsm.getValue(`ds1.id1.nonExisting`)).toBeUndefined();
     expect(dsm.getValue('non-existing-ds.id1.name')).toBeUndefined();
   });
 });

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -93,6 +93,7 @@ describe('DataSourceManager', () => {
       expect(dsm.setValue('ds1.id1.newField', 'new field value')).toBe(true);
       expect(dsm.getValue('ds1.id1.newField')).toBe('new field value');
       expect(dsm.setValue('non-existing-ds.id1.name', 'New Name')).toBe(false);
+      expect(dsm.setValue('non-existing-ds.none.name', 'New Name')).toBe(false);
 
       expect(dsm.setValue('invalid-path', 'New Name')).toBe(false);
     });
@@ -100,22 +101,26 @@ describe('DataSourceManager', () => {
     test('set nested values', () => {
       const ds = addDataSource();
       const address = { city: 'CityName' };
-      const roles = ['admin', 'user'];
+      const roles = ['admin', 'user', 'member'];
+      const newObj = { newValue: '1' };
       ds.addRecord({
         id: 'id4',
         name: 'Name4',
         metadata: { address, roles },
       });
 
-      // Update nested object property
+      // Check object updates
       expect(dsm.setValue('ds1.id4.metadata.address.city', 'NewCity')).toBe(true);
       expect(dsm.getValue('ds1.id4.metadata.address.city')).toBe('NewCity');
+      expect(dsm.setValue('ds1.id4.metadata.newObj', newObj)).toBe(true);
+      expect(dsm.getValue('ds1.id4.metadata.newObj')).toEqual(newObj);
 
-      // Update array item
+      // Check array updates
       expect(dsm.setValue('ds1.id4.metadata.roles[1]', 'editor')).toBe(true);
       expect(dsm.getValue('ds1.id4.metadata')).toEqual({
+        newObj: { newValue: '1' },
         address: { city: 'NewCity' },
-        roles: ['admin', 'editor'],
+        roles: ['admin', 'editor', 'member'],
       });
 
       // Set entirely new nested object
@@ -123,16 +128,26 @@ describe('DataSourceManager', () => {
       expect(dsm.setValue('ds1.id4.metadata.address', newAddress)).toBe(true);
       expect(dsm.getValue('ds1.id4.metadata.address')).toEqual(newAddress);
 
-      // Set new array
       const newRoles = ['editor', 'viewer'];
       expect(dsm.setValue('ds1.id4.metadata.roles', newRoles)).toBe(true);
       expect(dsm.getValue('ds1.id4.metadata.roles')).toEqual(newRoles);
+
+      expect(dsm.getValue('ds1.id4.metadata')).toEqual({
+        newObj: { newValue: '1' },
+        address: { city: 'AnotherCity', country: 'SomeCountry' },
+        roles: ['editor', 'viewer'],
+      });
 
       // Set completely new nested structure
       const newMetadata = { tags: ['tag1', 'tag2'], settings: { theme: 'dark' } };
       expect(dsm.setValue('ds1.id4.metadata', newMetadata)).toBe(true);
       expect(dsm.getValue('ds1.id4.metadata')).toEqual(newMetadata);
       expect(dsm.getValue('ds1.id4.metadata.settings.theme')).toBe('dark');
+
+      expect(dsm.getValue('ds1.id4.metadata')).toEqual({
+        tags: ['tag1', 'tag2'],
+        settings: { theme: 'dark' },
+      });
     });
   });
 });

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -35,7 +35,7 @@ describe('DataSourceManager', () => {
     em.on(dsm.events.add, eventAdd);
     const ds = addDataSource();
     expect(dsm.getAll().length).toBe(1);
-    expect(eventAdd).toBeCalledTimes(1);
+    expect(eventAdd).toHaveBeenCalledTimes(1);
     expect(ds.getRecords().length).toBe(3);
   });
 
@@ -50,7 +50,7 @@ describe('DataSourceManager', () => {
     const ds = addDataSource();
     dsm.remove('ds1');
     expect(dsm.getAll().length).toBe(0);
-    expect(event).toBeCalledTimes(1);
-    expect(event).toBeCalledWith(ds, expect.any(Object));
+    expect(event).toHaveBeenCalledTimes(1);
+    expect(event).toHaveBeenCalledWith(ds, expect.any(Object));
   });
 });

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -1,5 +1,5 @@
 import DataSourceManager from '../../../src/data_sources';
-import { DataSourceProps } from '../../../src/data_sources/types';
+import { DataSourceProps, DataFieldPrimitiveType } from '../../../src/data_sources/types';
 import { setupTestEditor } from '../../common';
 import EditorModel from '../../../src/editor/model/Editor';
 
@@ -52,5 +52,16 @@ describe('DataSourceManager', () => {
     expect(dsm.getAll().length).toBe(0);
     expect(event).toHaveBeenCalledTimes(1);
     expect(event).toHaveBeenCalledWith(ds, expect.any(Object));
+  });
+
+  test('getValue', () => {
+    const ds = addDataSource();
+    const testPath = ds.getRecord('id2')?.getPath('name') || '';
+    expect(dsm.getValue(`${ds.id}.id1.name`)).toBe('Name1');
+    expect(dsm.getValue(testPath)).toBe('Name2');
+    expect(dsm.getValue(`${ds.id}.non-existing.name`)).toBeUndefined();
+    expect(dsm.getValue(`${ds.id}.non-existing.name`, 'Default name')).toBe('Default name');
+    expect(dsm.getValue(`${ds.id}.id1.nonExisting`)).toBeUndefined();
+    expect(dsm.getValue('non-existing-ds.id1.name')).toBeUndefined();
   });
 });

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -6,7 +6,7 @@ import { setupTestEditor } from '../../common';
 describe('DataSourceManager', () => {
   let em: EditorModel;
   let dsm: DataSourceManager;
-  type Record = { id: string; name: string };
+  type Record = { id: string; name: string; metadata?: any };
   const dsTest: DataSourceProps<Record> = {
     id: 'ds1',
     records: [
@@ -54,15 +54,44 @@ describe('DataSourceManager', () => {
     expect(event).toHaveBeenCalledWith(ds, expect.any(Object));
   });
 
-  test('getValue', () => {
-    const ds = addDataSource();
-    const testPath = ds.getRecord('id2')?.getPath('name') || '';
-    expect(dsm.getValue(testPath)).toBe('Name2');
-    expect(dsm.getValue(`ds1.id1.name`)).toBe('Name1');
-    expect(dsm.getValue(`ds1[id1]name`)).toBe('Name1');
-    expect(dsm.getValue(`ds1.non-existing.name`)).toBeUndefined();
-    expect(dsm.getValue(`ds1.non-existing.name`, 'Default name')).toBe('Default name');
-    expect(dsm.getValue(`ds1.id1.nonExisting`)).toBeUndefined();
-    expect(dsm.getValue('non-existing-ds.id1.name')).toBeUndefined();
+  describe('getValue', () => {
+    test('getValue', () => {
+      const ds = addDataSource();
+      const testPath = ds.getRecord('id2')?.getPath('name') || '';
+      expect(dsm.getValue(testPath)).toBe('Name2');
+      expect(dsm.getValue(`ds1.id1.name`)).toBe('Name1');
+      expect(dsm.getValue(`ds1[id1]name`)).toBe('Name1');
+      expect(dsm.getValue(`ds1.non-existing.name`)).toBeUndefined();
+      expect(dsm.getValue(`ds1.non-existing.name`, 'Default name')).toBe('Default name');
+      expect(dsm.getValue(`ds1.id1.nonExisting`)).toBeUndefined();
+      expect(dsm.getValue('non-existing-ds.id1.name')).toBeUndefined();
+    });
+
+    test('getValue with nested values', () => {
+      const ds = addDataSource();
+      const address = { city: 'CityName' };
+      ds.addRecord({
+        id: 'id4',
+        name: 'Name4',
+        metadata: { address },
+      });
+
+      expect(dsm.getValue(`ds1.id4.metadata.address`)).toEqual(address);
+      expect(dsm.getValue(`ds1.id4.metadata.address.city`)).toEqual(address.city);
+    });
+  });
+
+  describe('setValue', () => {
+    test('Should set value in existing record', () => {
+      addDataSource();
+      expect(dsm.setValue('ds1.id1.name', 'Name1 Up')).toBe(true);
+      expect(dsm.getValue('ds1.id1.name')).toBe('Name1 Up');
+
+      expect(dsm.setValue('ds1.id1.newField', 'new field value')).toBe(true);
+      expect(dsm.getValue('ds1.id1.newField')).toBe('new field value');
+      expect(dsm.setValue('non-existing-ds.id1.name', 'New Name')).toBe(false);
+
+      expect(dsm.setValue('invalid-path', 'New Name')).toBe(false);
+    });
   });
 });

--- a/packages/core/test/specs/data_sources/index.ts
+++ b/packages/core/test/specs/data_sources/index.ts
@@ -1,7 +1,7 @@
 import DataSourceManager from '../../../src/data_sources';
-import { DataSourceProps, DataFieldPrimitiveType } from '../../../src/data_sources/types';
-import { setupTestEditor } from '../../common';
+import { DataSourceProps } from '../../../src/data_sources/types';
 import EditorModel from '../../../src/editor/model/Editor';
+import { setupTestEditor } from '../../common';
 
 describe('DataSourceManager', () => {
   let em: EditorModel;

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -5,6 +5,7 @@ import {
   DataFieldSchemaNumber,
   DataFieldSchemaString,
   DataRecordProps,
+  DataSourceProviderResult,
 } from '../../../../src/data_sources/types';
 import Editor from '../../../../src/editor/model/Editor';
 import { setupTestEditor } from '../../../common';
@@ -20,6 +21,21 @@ describe('DataSource', () => {
   let em: Editor;
   let dsm: DataSourceManager;
   let ds: DataSource<TestRecord>;
+  const categoryRecords = [
+    { id: 'cat1', uid: 'cat1-uid', name: 'Category 1' },
+    { id: 'cat2', uid: 'cat2-uid', name: 'Category 2' },
+    { id: 'cat3', uid: 'cat3-uid', name: 'Category 3' },
+  ];
+  const userRecords = [
+    { id: 'user1', username: 'user_one' },
+    { id: 'user2', username: 'user_two' },
+    { id: 'user3', username: 'user_three' },
+  ];
+  const blogRecords = [
+    { id: 'blog1', title: 'First Blog', author: 'user1', categories: ['cat1-uid'] },
+    { id: 'blog2', title: 'Second Blog', author: 'user2' },
+    { id: 'blog3', title: 'Third Blog', categories: ['cat1-uid', 'cat3-uid'] },
+  ];
 
   const addTestDataSource = (records?: TestRecord[]) => {
     return dsm.add<TestRecord>({ id: 'test', records: records || [{ id: 'user1', age: 30 }] });
@@ -84,22 +100,6 @@ describe('DataSource', () => {
     });
 
     describe('Relations', () => {
-      const categoryRecords = [
-        { id: 'cat1', uid: 'cat1-uid', name: 'Category 1' },
-        { id: 'cat2', uid: 'cat2-uid', name: 'Category 2' },
-        { id: 'cat3', uid: 'cat3-uid', name: 'Category 3' },
-      ];
-      const userRecords = [
-        { id: 'user1', username: 'user_one' },
-        { id: 'user2', username: 'user_two' },
-        { id: 'user3', username: 'user_three' },
-      ];
-      const blogRecords = [
-        { id: 'blog1', title: 'First Blog', author: 'user1', categories: ['cat1-uid'] },
-        { id: 'blog2', title: 'Second Blog', author: 'user2' },
-        { id: 'blog3', title: 'Third Blog', categories: ['cat1-uid', 'cat3-uid'] },
-      ];
-
       beforeEach(() => {
         dsm.add({
           id: 'categories',
@@ -157,6 +157,51 @@ describe('DataSource', () => {
           { ...blogRecords[2], categories: [categoryRecords[0], categoryRecords[2]] },
         ]);
       });
+    });
+  });
+
+  describe('Providers', () => {
+    const testApiUrl = 'https://api.example.com/data';
+    const getMockSchema = () => ({
+      author: {
+        type: DataFieldPrimitiveType.relation,
+        target: 'users',
+        targetField: 'id',
+      },
+    });
+    const getMockProviderResponse: () => DataSourceProviderResult = () => ({
+      records: blogRecords,
+      schema: getMockSchema(),
+    });
+
+    beforeEach(() => {
+      dsm.add({
+        id: 'categories',
+        records: categoryRecords,
+      });
+      dsm.add({
+        id: 'users',
+        records: userRecords,
+      });
+    });
+
+    test('loadProvider', async () => {
+      const ds = dsm.add({
+        id: 'blogs',
+        provider: {
+          get: {
+            url: testApiUrl,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        },
+      });
+
+      expect(ds.schema).toEqual(getMockSchema());
+      expect(ds.getResolvedRecords()).toEqual([
+        { ...blogRecords[0], author: userRecords[0] },
+        { ...blogRecords[1], author: userRecords[1] },
+        blogRecords[2],
+      ]);
     });
   });
 });

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -184,7 +184,7 @@ describe('DataSource', () => {
     };
 
     beforeEach(() => {
-      jest.spyOn(global, 'fetch').mockImplementation((url) =>
+      jest.spyOn(global, 'fetch').mockImplementation(() =>
         Promise.resolve({
           ok: true,
           json: () => Promise.resolve(getMockProviderResponse()),

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -14,6 +14,8 @@ interface TestRecord extends DataRecordProps {
   age?: number;
 }
 
+const serializeRecords = (records: any[]) => JSON.parse(JSON.stringify(records));
+
 describe('DataSource', () => {
   let em: Editor;
   let dsm: DataSourceManager;
@@ -79,6 +81,62 @@ describe('DataSource', () => {
       expect(ds.getSchemaField('name')).toEqual(schemaName);
       expect(ds.getSchemaField('age')).toEqual(schemaAge);
       expect(ds.getSchemaField('nonExistentField')).toBeUndefined();
+    });
+
+    describe('Relations', () => {
+      const categoryRecords = [
+        { id: 'cat1', name: 'Category 1' },
+        { id: 'cat2', name: 'Category 2' },
+      ];
+      const userRecords = [
+        { id: 'user1', username: 'user_one' },
+        { id: 'user2', username: 'user_two' },
+      ];
+      const blogRecords = [
+        { id: 'blog1', title: 'First Blog', author: 'user1', categories: ['cat1'] },
+        { id: 'blog2', title: 'Second Blog', author: 'user2' },
+        { id: 'blog3', title: 'Third Blog', categories: ['cat1', 'cat2'] },
+      ];
+
+      beforeEach(() => {
+        dsm.add({
+          id: 'categories',
+          records: categoryRecords,
+        });
+        dsm.add({
+          id: 'users',
+          records: userRecords,
+        });
+        dsm.add({
+          id: 'blogs',
+          records: blogRecords,
+          schema: {
+            title: {
+              type: DataFieldPrimitiveType.string,
+            },
+            author: {
+              type: DataFieldPrimitiveType.relation,
+              target: 'users',
+              targetField: 'id',
+            },
+          },
+        });
+      });
+
+      test('return default values', () => {
+        const blogsDS = dsm.get('blogs');
+        expect(serializeRecords(blogsDS.getRecords())).toEqual(blogRecords);
+      });
+
+      test('return resolved values', () => {
+        const blogsDS = dsm.get('blogs');
+        const records = blogsDS.getRecords({ resolveRelations: true });
+        expect(records).toEqual([
+          { ...blogRecords[0], author: userRecords[0] },
+          { ...blogRecords[1], author: userRecords[1] },
+          blogRecords[2],
+        ]);
+      });
     });
   });
 });

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -1,0 +1,84 @@
+import { DataSourceManager } from '../../../../src';
+import DataSource from '../../../../src/data_sources/model/DataSource';
+import {
+  DataFieldPrimitiveType,
+  DataFieldSchemaNumber,
+  DataFieldSchemaString,
+  DataRecordProps,
+} from '../../../../src/data_sources/types';
+import Editor from '../../../../src/editor/model/Editor';
+import { setupTestEditor } from '../../../common';
+
+interface TestRecord extends DataRecordProps {
+  name?: string;
+  age?: number;
+}
+
+describe('DataSource', () => {
+  let em: Editor;
+  let dsm: DataSourceManager;
+  let ds: DataSource<TestRecord>;
+
+  const addTestDataSource = (records?: TestRecord[]) => {
+    return dsm.add<TestRecord>({ id: 'test', records: records || [{ id: 'user1', age: 30 }] });
+  };
+
+  beforeEach(() => {
+    ({ em, dsm } = setupTestEditor());
+  });
+
+  afterEach(() => {
+    em.destroy();
+  });
+
+  describe('Schema', () => {
+    const schemaName: DataFieldSchemaString = {
+      type: DataFieldPrimitiveType.string,
+      label: 'Name',
+    };
+    const schemaAge: DataFieldSchemaNumber = {
+      type: DataFieldPrimitiveType.number,
+      label: 'Age',
+      default: 18,
+    };
+
+    beforeEach(() => {
+      ds = addTestDataSource();
+    });
+
+    test('Initialize with empty schema', () => {
+      expect(ds.schema).toEqual({});
+    });
+
+    test('Add and update schema', () => {
+      const schemaNameDef: typeof ds.schema = { name: schemaName };
+      const schemaAgeDef: typeof ds.schema = { age: schemaAge };
+      ds.upSchema(schemaNameDef);
+      ds.upSchema(schemaAgeDef);
+      expect(ds.schema).toEqual({ ...schemaNameDef, ...schemaAgeDef });
+    });
+
+    test('Should update existing field schema', () => {
+      ds.upSchema({ name: schemaName });
+
+      const updatedSchema: typeof ds.schema = {
+        name: {
+          ...schemaName,
+          description: 'User name field',
+        },
+      };
+      ds.upSchema(updatedSchema);
+      expect(ds.schema).toEqual(updatedSchema);
+    });
+
+    test('Should get field schema', () => {
+      ds.upSchema({
+        name: schemaName,
+        age: schemaAge,
+      });
+      expect(ds.getSchemaField('name')).toEqual(schemaName);
+      expect(ds.getSchemaField('age')).toEqual(schemaAge);
+      expect(ds.getSchemaField('nonExistentField')).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -85,17 +85,17 @@ describe('DataSource', () => {
 
     describe('Relations', () => {
       const categoryRecords = [
-        { id: 'cat1', name: 'Category 1' },
-        { id: 'cat2', name: 'Category 2' },
+        { id: 'cat1', uid: 'cat1-uid', name: 'Category 1' },
+        { id: 'cat2', uid: 'cat2-uid', name: 'Category 2' },
       ];
       const userRecords = [
         { id: 'user1', username: 'user_one' },
         { id: 'user2', username: 'user_two' },
       ];
       const blogRecords = [
-        { id: 'blog1', title: 'First Blog', author: 'user1', categories: ['cat1'] },
+        { id: 'blog1', title: 'First Blog', author: 'user1', categories: ['cat1-uid'] },
         { id: 'blog2', title: 'Second Blog', author: 'user2' },
-        { id: 'blog3', title: 'Third Blog', categories: ['cat1', 'cat2'] },
+        { id: 'blog3', title: 'Third Blog', categories: ['cat1-uid', 'cat2-uid'] },
       ];
 
       beforeEach(() => {
@@ -128,9 +128,9 @@ describe('DataSource', () => {
         expect(serializeRecords(blogsDS.getRecords())).toEqual(blogRecords);
       });
 
-      test('return resolved values', () => {
+      test('return 1:1 resolved values', () => {
         const blogsDS = dsm.get('blogs');
-        const records = blogsDS.getRecords({ resolveRelations: true });
+        const records = blogsDS.getResolvedRecords();
         expect(records).toEqual([
           { ...blogRecords[0], author: userRecords[0] },
           { ...blogRecords[1], author: userRecords[1] },

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -162,6 +162,7 @@ describe('DataSource', () => {
 
   describe('Providers', () => {
     const testApiUrl = 'https://api.example.com/data';
+    const testHeaders = { 'Content-Type': 'application/json' };
     const getMockSchema = () => ({
       author: {
         type: DataFieldPrimitiveType.relation,
@@ -173,8 +174,23 @@ describe('DataSource', () => {
       records: blogRecords,
       schema: getMockSchema(),
     });
+    const addBlogsWithProvider = () => {
+      return dsm.add({
+        id: 'blogs',
+        provider: {
+          get: { url: testApiUrl, headers: testHeaders },
+        },
+      });
+    };
 
     beforeEach(() => {
+      jest.spyOn(global, 'fetch').mockImplementation((url) =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(getMockProviderResponse()),
+        } as Response),
+      );
+
       dsm.add({
         id: 'categories',
         records: categoryRecords,
@@ -185,23 +201,33 @@ describe('DataSource', () => {
       });
     });
 
-    test('loadProvider', async () => {
-      const ds = dsm.add({
-        id: 'blogs',
-        provider: {
-          get: {
-            url: testApiUrl,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        },
-      });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
+    test('loadProvider', async () => {
+      const ds = addBlogsWithProvider();
+      await ds.loadProvider();
+
+      expect(fetch).toHaveBeenCalledWith(testApiUrl, { headers: testHeaders });
       expect(ds.schema).toEqual(getMockSchema());
       expect(ds.getResolvedRecords()).toEqual([
         { ...blogRecords[0], author: userRecords[0] },
         { ...blogRecords[1], author: userRecords[1] },
         blogRecords[2],
       ]);
+    });
+
+    test('loadProvider with failed fetch', async () => {
+      jest.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+
+      em.config.log = false;
+      const ds = addBlogsWithProvider();
+      await ds.loadProvider();
+
+      expect(fetch).toHaveBeenCalledWith(testApiUrl, { headers: testHeaders });
+      expect(ds.schema).toEqual({});
+      expect(ds.getRecords().length).toBe(0);
     });
   });
 });

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -87,15 +87,17 @@ describe('DataSource', () => {
       const categoryRecords = [
         { id: 'cat1', uid: 'cat1-uid', name: 'Category 1' },
         { id: 'cat2', uid: 'cat2-uid', name: 'Category 2' },
+        { id: 'cat3', uid: 'cat3-uid', name: 'Category 3' },
       ];
       const userRecords = [
         { id: 'user1', username: 'user_one' },
         { id: 'user2', username: 'user_two' },
+        { id: 'user3', username: 'user_three' },
       ];
       const blogRecords = [
         { id: 'blog1', title: 'First Blog', author: 'user1', categories: ['cat1-uid'] },
         { id: 'blog2', title: 'Second Blog', author: 'user2' },
-        { id: 'blog3', title: 'Third Blog', categories: ['cat1-uid', 'cat2-uid'] },
+        { id: 'blog3', title: 'Third Blog', categories: ['cat1-uid', 'cat3-uid'] },
       ];
 
       beforeEach(() => {
@@ -135,6 +137,24 @@ describe('DataSource', () => {
           { ...blogRecords[0], author: userRecords[0] },
           { ...blogRecords[1], author: userRecords[1] },
           blogRecords[2],
+        ]);
+      });
+
+      test('return 1:many resolved values', () => {
+        const blogsDS = dsm.get('blogs');
+        blogsDS.upSchema({
+          categories: {
+            type: DataFieldPrimitiveType.relation,
+            target: 'categories',
+            targetField: 'uid',
+            isMany: true,
+          },
+        });
+        const records = blogsDS.getResolvedRecords();
+        expect(records).toEqual([
+          { ...blogRecords[0], author: userRecords[0], categories: [categoryRecords[0]] },
+          { ...blogRecords[1], author: userRecords[1] },
+          { ...blogRecords[2], categories: [categoryRecords[0], categoryRecords[2]] },
         ]);
       });
     });

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -179,6 +179,7 @@ describe('DataSource', () => {
     const addBlogsWithProvider = () => {
       return dsm.add({
         id: 'blogs',
+        name: 'My blogs',
         provider: {
           get: getProviderBlogsGet(),
         },
@@ -232,8 +233,11 @@ describe('DataSource', () => {
       expect(ds.getRecords().length).toBe(0);
     });
 
-    test('ensure records loaded from the provider are not persisted', async () => {
+    test('records loaded from the provider are not persisted', async () => {
       const ds = addBlogsWithProvider();
+      const eventLoad = jest.fn();
+      em.on(dsm.events.providerLoad, eventLoad);
+
       await ds.loadProvider();
 
       expect(editor.getProjectData().dataSources).toEqual([
@@ -241,12 +245,51 @@ describe('DataSource', () => {
         { id: 'users', records: userRecords },
         {
           id: 'blogs',
+          name: 'My blogs',
           schema: getMockSchema(),
-          provider: {
-            get: getProviderBlogsGet(),
-          },
+          provider: { get: getProviderBlogsGet() },
         },
       ]);
+      expect(eventLoad).toHaveBeenCalledTimes(1);
+      expect(eventLoad).toHaveBeenCalledWith({
+        dataSource: ds,
+        result: getMockProviderResponse(),
+      });
+    });
+
+    test('load providers on project load', (done) => {
+      dsm.getConfig().autoloadProviders = true;
+
+      editor.on(dsm.events.providerLoadAll, () => {
+        expect(dsm.get('blogs').getResolvedRecords()).toEqual([
+          { ...blogRecords[0], author: userRecords[0] },
+          { ...blogRecords[1], author: userRecords[1] },
+          blogRecords[2],
+        ]);
+
+        expect(editor.getProjectData().dataSources).toEqual([
+          { id: 'categories', records: categoryRecords },
+          { id: 'users', records: userRecords },
+          {
+            id: 'blogs',
+            schema: getMockSchema(),
+            provider: { get: testApiUrl },
+          },
+        ]);
+
+        done();
+      });
+
+      editor.loadProjectData({
+        dataSources: [
+          { id: 'categories', records: categoryRecords },
+          { id: 'users', records: userRecords },
+          {
+            id: 'blogs',
+            provider: { get: testApiUrl },
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/core/test/specs/data_sources/model/DataSource.ts
+++ b/packages/core/test/specs/data_sources/model/DataSource.ts
@@ -19,6 +19,7 @@ const serializeRecords = (records: any[]) => JSON.parse(JSON.stringify(records))
 
 describe('DataSource', () => {
   let em: Editor;
+  let editor: Editor['Editor'];
   let dsm: DataSourceManager;
   let ds: DataSource<TestRecord>;
   const categoryRecords = [
@@ -42,7 +43,7 @@ describe('DataSource', () => {
   };
 
   beforeEach(() => {
-    ({ em, dsm } = setupTestEditor());
+    ({ em, dsm, editor } = setupTestEditor());
   });
 
   afterEach(() => {
@@ -174,11 +175,12 @@ describe('DataSource', () => {
       records: blogRecords,
       schema: getMockSchema(),
     });
+    const getProviderBlogsGet = () => ({ url: testApiUrl, headers: testHeaders });
     const addBlogsWithProvider = () => {
       return dsm.add({
         id: 'blogs',
         provider: {
-          get: { url: testApiUrl, headers: testHeaders },
+          get: getProviderBlogsGet(),
         },
       });
     };
@@ -228,6 +230,23 @@ describe('DataSource', () => {
       expect(fetch).toHaveBeenCalledWith(testApiUrl, { headers: testHeaders });
       expect(ds.schema).toEqual({});
       expect(ds.getRecords().length).toBe(0);
+    });
+
+    test('ensure records loaded from the provider are not persisted', async () => {
+      const ds = addBlogsWithProvider();
+      await ds.loadProvider();
+
+      expect(editor.getProjectData().dataSources).toEqual([
+        { id: 'categories', records: categoryRecords },
+        { id: 'users', records: userRecords },
+        {
+          id: 'blogs',
+          schema: getMockSchema(),
+          provider: {
+            get: getProviderBlogsGet(),
+          },
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Schema support with relations

Added schema support to DataSource with field type definitions and relation capabilities:

```js
const dsm = editor.DataSources;

dsm.add({
  id: 'categories',
  records: [
    { id: 'cat1', uid: 'cat1-uid', name: 'Category 1' },
    { id: 'cat2', uid: 'cat2-uid', name: 'Category 2' },
    { id: 'cat3', uid: 'cat3-uid', name: 'Category 3' },
  ],
});

dsm.add({
 id: 'users',
 records: [
    { id: 'user1', username: 'user_one' },
    { id: 'user2', username: 'user_two' },
    { id: 'user3', username: 'user_three' },
  ],
});

const blogsDS  = dsm.add({
  id: 'blogs',
  records: [
    { id: 'blog1', title: 'First Blog', author: 'user1', categories: ['cat1-uid'] },
    { id: 'blog2', title: 'Second Blog', author: 'user2' },
    { id: 'blog3', title: 'Third Blog', categories: ['cat1-uid', 'cat3-uid'] },
  ],
  schema: {
    author: { type: DataFieldPrimitiveType.relation, target: 'users' },
    categories: { 
      type: DataFieldPrimitiveType.relation, 
      target: 'categories',  // Target data source
      targetField: 'uid',      // Field to match (defaults to 'id')
      isMany: true,          // One-to-many relation
    },
  },
});

// Get resolved records with populated relations
const blogs = blogsDS.getResolvedRecords();
// Result:
[
  { 
    id: 'blog1',
    title: 'First Blog',
    author: { id: 'user1', name: 'user_one' },
    categories: [
      { id: 'cat1', uid: 'cat1-uid', name: 'Category 1' }    
    ]
  },
 // ...
]
```

## Provider Support

Added provider support for external data

```js
dsm.add({
  id: 'blogs',
  name: 'My blogs',
  provider: { get:'https://api.example.com/data' },
});

// The provider API is expected to receive this JSON (schema is optional)
{
  records: [
    { id: 'blog1', title: 'Blog post 1', ... }
  ],
  schema: {
    author: {
      type: 'relation',
      target: 'users'
    }
  }
}
```

When the `provider` is set on the data source, the records won't be exported in the project JSON but will be loaded on project JSON load. This is an ideal case for managing a lot of records without storing them directly in the project.
