### PR TITLE
Add/p2p

### DIFF
--- a/packages/core/demo-p2p/collaborative-manager.js
+++ b/packages/core/demo-p2p/collaborative-manager.js
@@ -1,0 +1,326 @@
+// collaborative-manager.js
+
+class CollaborativeManager {
+  constructor(editor, options = {}) {
+    this.editor = editor;
+    this.options = {
+      signalingUrl: 'ws://localhost:3001',
+      roomId: 'demo-room',
+      clientId: this._generateClientId(),
+      enable: true,
+      ...options,
+    };
+
+    if (!this.options.enable) return;
+
+    this.ws = null;
+    this.peers = new Map(); // peerId -> { pc, dc }
+    this.patchSeq = 0;
+    this.seenPatches = new Set(); // for loop protection
+    this.isApplyingRemote = false;
+
+    this._connectSignaling();
+    this._bindEditorEvents();
+  }
+
+  _generateClientId() {
+    return 'c_' + Math.random().toString(36).slice(2);
+  }
+
+  _connectSignaling() {
+    const { signalingUrl, roomId, clientId } = this.options;
+    const url = `${signalingUrl}?roomId=${encodeURIComponent(roomId)}&clientId=${encodeURIComponent(clientId)}`;
+    const ws = new WebSocket(url);
+
+    this.ws = ws;
+
+    ws.onopen = () => {
+      console.log('[Collab] Signaling connected as', clientId);
+    };
+
+    ws.onmessage = async (event) => {
+      const data = JSON.parse(event.data);
+      const { type, from } = data;
+
+      if (from === this.options.clientId) return; // ignore self
+
+      switch (type) {
+        case 'connected':
+          // server's hello, содержит clientId (наш)
+          break;
+
+        case 'peer-join':
+          // Новый peer в комнате: мы инициатор, создаем offer
+          this._createPeerConnection(from, true);
+          break;
+
+        case 'peer-leave':
+          this._closePeer(from);
+          break;
+
+        case 'offer':
+          await this._onOffer(from, data);
+          break;
+
+        case 'answer':
+          await this._onAnswer(from, data);
+          break;
+
+        case 'candidate':
+          await this._onCandidate(from, data);
+          break;
+
+        default:
+          break;
+      }
+    };
+
+    ws.onclose = () => {
+      console.log('[Collab] Signaling closed, try reconnect later if needed');
+      // Можно добавить автоматический reconnect при желании
+    };
+  }
+
+  _sendSignal(message) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(message));
+    }
+  }
+
+  _createPeerConnection(peerId, isInitiator) {
+    if (this.peers.has(peerId)) return this.peers.get(peerId);
+
+    const pc = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+    });
+
+    let dc;
+
+    if (isInitiator) {
+      dc = pc.createDataChannel('patches');
+      this._setupDataChannel(peerId, dc);
+      this._createOffer(peerId, pc);
+    } else {
+      // dataChannel будет создан на ondatachannel
+      pc.ondatachannel = (event) => {
+        dc = event.channel;
+        this._setupDataChannel(peerId, dc);
+      };
+    }
+
+    pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        this._sendSignal({
+          type: 'candidate',
+          candidate: event.candidate,
+          to: peerId,
+        });
+      }
+    };
+
+    pc.onconnectionstatechange = () => {
+      console.log('[Collab] Peer', peerId, 'state:', pc.connectionState);
+      if (pc.connectionState === 'disconnected' || pc.connectionState === 'failed' || pc.connectionState === 'closed') {
+        this._closePeer(peerId);
+      }
+    };
+
+    const peer = { pc, dc: null };
+    this.peers.set(peerId, peer);
+    return peer;
+  }
+
+  async _createOffer(peerId, pc) {
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    this._sendSignal({
+      type: 'offer',
+      to: peerId,
+      sdp: offer,
+    });
+  }
+
+  async _onOffer(peerId, data) {
+    const peer = this._createPeerConnection(peerId, false);
+    const { pc } = peer;
+
+    await pc.setRemoteDescription(new RTCSessionDescription(data.sdp));
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+
+    this._sendSignal({
+      type: 'answer',
+      to: peerId,
+      sdp: answer,
+    });
+  }
+
+  async _onAnswer(peerId, data) {
+    const peer = this.peers.get(peerId);
+    if (!peer) return;
+    const { pc } = peer;
+    await pc.setRemoteDescription(new RTCSessionDescription(data.sdp));
+  }
+
+  async _onCandidate(peerId, data) {
+    const peer = this.peers.get(peerId);
+    if (!peer) return;
+    if (!data.candidate) return;
+
+    try {
+      await peer.pc.addIceCandidate(new RTCIceCandidate(data.candidate));
+    } catch (err) {
+      console.error('[Collab] Error adding candidate', err);
+    }
+  }
+
+  _setupDataChannel(peerId, dc) {
+    console.log('[Collab] DataChannel opened with peer', peerId);
+    this.peers.get(peerId).dc = dc;
+
+    dc.onopen = () => {
+      console.log('[Collab] DC open:', peerId);
+    };
+
+    dc.onclose = () => {
+      console.log('[Collab] DC close:', peerId);
+    };
+
+    dc.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+        this._onDataChannelMessage(peerId, msg);
+      } catch (e) {
+        console.error('[Collab] Invalid DC message', e);
+      }
+    };
+  }
+
+  _onDataChannelMessage(peerId, msg) {
+    if (msg.type === 'patch') {
+      const { clientId, patchSeq, patches } = msg;
+
+      // Loop protection: пропускаем свои и уже обработанные
+      const key = `${clientId}:${patchSeq}`;
+      if (clientId === this.options.clientId) return;
+      if (this.seenPatches.has(key)) return;
+      this.seenPatches.add(key);
+
+      // Применяем патч локально
+      this.applyRemotePatch(patches, { from: clientId, patchSeq });
+
+      // И (опционально) ретранслируем дальше другим пирами
+      this._rebroadcastPatchFromPeer(peerId, msg);
+    }
+  }
+
+  _rebroadcastPatchFromPeer(sourcePeerId, msg) {
+    // Патч уже имеет clientId/patchSeq, так что другие клиенты
+    // отфильтруют дубликаты по seenPatches.
+    for (const [peerId, peer] of this.peers.entries()) {
+      if (peerId === sourcePeerId) continue;
+      if (peer.dc && peer.dc.readyState === 'open') {
+        peer.dc.send(JSON.stringify(msg));
+      }
+    }
+  }
+
+  _closePeer(peerId) {
+    const peer = this.peers.get(peerId);
+    if (!peer) return;
+    if (peer.dc) {
+      try {
+        peer.dc.close();
+      } catch {}
+    }
+    if (peer.pc) {
+      try {
+        peer.pc.close();
+      } catch {}
+    }
+    this.peers.delete(peerId);
+    console.log('[Collab] Peer closed', peerId);
+  }
+
+  _bindEditorEvents() {
+    const { editor } = this;
+
+    // Здесь предполагаем, что PatchManager триггерит patch:update с {patches}
+    editor.on('patch:update', ({ patches }) => {
+      if (this.isApplyingRemote) return; // не пересылать то, что сами же получили
+      this._broadcastPatch(patches);
+    });
+
+    // По желанию можно прокидывать undo/redo как патчи:
+    editor.on('patch:undo', ({ patch }) => {
+      if (this.isApplyingRemote) return;
+      this._broadcastPatch(patch);
+    });
+
+    editor.on('patch:redo', ({ patch }) => {
+      if (this.isApplyingRemote) return;
+      this._broadcastPatch(patch);
+    });
+  }
+
+  _broadcastPatch(patches) {
+    this.patchSeq += 1;
+    const message = {
+      type: 'patch',
+      clientId: this.options.clientId,
+      patchSeq: this.patchSeq,
+      patches,
+    };
+
+    for (const [, peer] of this.peers.entries()) {
+      if (peer.dc && peer.dc.readyState === 'open') {
+        peer.dc.send(JSON.stringify(message));
+      }
+    }
+  }
+
+  // === ВАЖНО: адаптируй к своему PatchManager API ===
+  applyRemotePatch(patches, meta = {}) {
+    this.isApplyingRemote = true;
+    try {
+      const pm = this.editor.PatchManager || this.editor.PatchModule || this.editor.Patch;
+      if (pm && typeof pm.applyPatches === 'function') {
+        pm.applyPatches(patches, { remote: true, ...meta });
+      } else if (pm && typeof pm.applyPatch === 'function') {
+        pm.applyPatch(patches, { remote: true, ...meta });
+      } else {
+        // fallback: если у тебя есть кастомный API, просто вызови его
+        console.warn('[Collab] No PatchManager.apply* found, implement here');
+      }
+    } finally {
+      this.isApplyingRemote = false;
+    }
+  }
+}
+
+// Чтобы можно было использовать как "плагин" GrapesJS
+function CollaborativePlugin(editor, opts = {}) {
+  const cfg = {
+    collaboration: {
+      enable: false,
+      signalingUrl: 'ws://localhost:3001',
+      roomId: 'demo-room',
+      clientId: null,
+      ...opts.collaboration,
+    },
+    ...opts,
+  };
+
+  if (!cfg.collaboration.enable) return;
+
+  const clientId = cfg.collaboration.clientId || 'c_' + Math.random().toString(36).slice(2);
+  editor.CollaborativeManager = new CollaborativeManager(editor, {
+    signalingUrl: cfg.collaboration.signalingUrl,
+    roomId: cfg.collaboration.roomId,
+    clientId,
+    enable: true,
+  });
+}
+
+window.CollaborativeManager = CollaborativeManager;
+window.CollaborativePlugin = CollaborativePlugin;

--- a/packages/core/demo-p2p/collaborative-manager.js
+++ b/packages/core/demo-p2p/collaborative-manager.js
@@ -8,16 +8,21 @@ class CollaborativeManager {
       roomId: 'demo-room',
       clientId: this._generateClientId(),
       enable: true,
+      debug: false,
       ...options,
     };
 
     if (!this.options.enable) return;
 
+    this.debug = !!this.options.debug;
     this.ws = null;
     this.peers = new Map(); // peerId -> { pc, dc }
     this.patchSeq = 0;
     this.seenPatches = new Set(); // for loop protection
     this.isApplyingRemote = false;
+
+    this.isSynced = false;
+    this.pendingPatches = []; // queued patches while waiting for init-state
 
     this._connectSignaling();
     this._bindEditorEvents();
@@ -25,6 +30,16 @@ class CollaborativeManager {
 
   _generateClientId() {
     return 'c_' + Math.random().toString(36).slice(2);
+  }
+
+  _isLeader(peerId) {
+    return this.options.clientId < peerId;
+  }
+
+  _log(...args) {
+    if (this.debug) {
+      console.log(...args);
+    }
   }
 
   _connectSignaling() {
@@ -87,23 +102,40 @@ class CollaborativeManager {
     }
   }
 
+  _sendData(dc, message) {
+    if (dc && dc.readyState === 'open') {
+      try {
+        dc.send(JSON.stringify(message));
+      } catch (err) {
+        console.warn('[Collab] Failed to send datachannel message', err);
+      }
+    }
+  }
+
   _createPeerConnection(peerId, isInitiator) {
+    console.log('[Collab] createPeerConnection to', peerId, 'initiator:', isInitiator);
+
     if (this.peers.has(peerId)) return this.peers.get(peerId);
 
     const pc = new RTCPeerConnection({
       iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
     });
 
-    let dc;
+    // СНАЧАЛА создаём и сохраняем peer
+    const peer = { pc, dc: null };
+    this.peers.set(peerId, peer);
 
     if (isInitiator) {
-      dc = pc.createDataChannel('patches');
+      // инициатор сам создаёт DataChannel
+      const dc = pc.createDataChannel('patches');
+      peer.dc = dc;
       this._setupDataChannel(peerId, dc);
       this._createOffer(peerId, pc);
     } else {
-      // dataChannel будет создан на ondatachannel
+      // принимающая сторона ждёт ondatachannel
       pc.ondatachannel = (event) => {
-        dc = event.channel;
+        const dc = event.channel;
+        peer.dc = dc;
         this._setupDataChannel(peerId, dc);
       };
     }
@@ -125,8 +157,6 @@ class CollaborativeManager {
       }
     };
 
-    const peer = { pc, dc: null };
-    this.peers.set(peerId, peer);
     return peer;
   }
 
@@ -175,11 +205,26 @@ class CollaborativeManager {
   }
 
   _setupDataChannel(peerId, dc) {
-    console.log('[Collab] DataChannel opened with peer', peerId);
-    this.peers.get(peerId).dc = dc;
+    console.log('[Collab] DataChannel created for peer', peerId);
 
     dc.onopen = () => {
       console.log('[Collab] DC open:', peerId);
+
+      // Очень простой выбор "лидера": клиент с минимальным clientId
+      const isLeader = this._isLeader(peerId); // строковое сравнение достаточно для демки
+
+      if (isLeader) {
+        const project = this.editor.getProjectData();
+        const msg = {
+          type: 'init-state',
+          project,
+        };
+        this._log('[Collab] send init-state to', peerId);
+        this._sendData(dc, msg);
+        this._markSynced('leader');
+      } else {
+        this._log('[Collab] waiting for init-state from leader', peerId);
+      }
     };
 
     dc.onclose = () => {
@@ -197,21 +242,57 @@ class CollaborativeManager {
   }
 
   _onDataChannelMessage(peerId, msg) {
+    if (msg.type === 'init-state') {
+      console.log('[Collab] received init-state from', peerId, msg);
+
+      // Полная синхронизация проекта
+      this.editor.loadProjectData(msg.project, { clear: true });
+      this._markSynced('init-state');
+      return;
+    }
+
     if (msg.type === 'patch') {
       const { clientId, patchSeq, patches } = msg;
 
-      // Loop protection: пропускаем свои и уже обработанные
+      console.log('[Collab] got patch from peer', peerId, 'client', clientId, 'seq', patchSeq, patches);
+
       const key = `${clientId}:${patchSeq}`;
       if (clientId === this.options.clientId) return;
       if (this.seenPatches.has(key)) return;
       this.seenPatches.add(key);
 
-      // Применяем патч локально
-      this.applyRemotePatch(patches, { from: clientId, patchSeq });
+      const meta = { from: clientId, patchSeq };
 
-      // И (опционально) ретранслируем дальше другим пирами
+      if (!this.isSynced) {
+        console.log('[Collab] not synced yet, queue patch', meta);
+        this.pendingPatches.push({ patch: patches, meta, sourcePeerId: peerId, raw: msg });
+        return;
+      }
+
+      // patches здесь == один PatchProps
+      this.applyRemotePatch(patches, meta);
       this._rebroadcastPatchFromPeer(peerId, msg);
     }
+  }
+
+  _markSynced(reason) {
+    if (this.isSynced) return;
+    this.isSynced = true;
+    this._log('[Collab] synced', reason, 'pending', this.pendingPatches.length);
+    this._flushPendingPatches();
+  }
+
+  _flushPendingPatches() {
+    if (!this.isSynced || !this.pendingPatches.length) return;
+    const queued = this.pendingPatches.slice();
+    this.pendingPatches = [];
+
+    queued.forEach((item) => {
+      this.applyRemotePatch(item.patch, item.meta);
+      if (item.raw) {
+        this._rebroadcastPatchFromPeer(item.sourcePeerId, item.raw);
+      }
+    });
   }
 
   _rebroadcastPatchFromPeer(sourcePeerId, msg) {
@@ -220,7 +301,7 @@ class CollaborativeManager {
     for (const [peerId, peer] of this.peers.entries()) {
       if (peerId === sourcePeerId) continue;
       if (peer.dc && peer.dc.readyState === 'open') {
-        peer.dc.send(JSON.stringify(msg));
+        this._sendData(peer.dc, msg);
       }
     }
   }
@@ -245,53 +326,75 @@ class CollaborativeManager {
   _bindEditorEvents() {
     const { editor } = this;
 
-    // Здесь предполагаем, что PatchManager триггерит patch:update с {patches}
-    editor.on('patch:update', ({ patches }) => {
-      if (this.isApplyingRemote) return; // не пересылать то, что сами же получили
-      this._broadcastPatch(patches);
-    });
+    const getPatch = (ev) => ev && (ev.patch || ev.patches || ev);
 
-    // По желанию можно прокидывать undo/redo как патчи:
-    editor.on('patch:undo', ({ patch }) => {
+    editor.on('patch:update', (ev) => {
+      const patch = getPatch(ev);
+      console.log('[Collab] local patch:update', patch);
+
+      if (!patch) return;
       if (this.isApplyingRemote) return;
+
       this._broadcastPatch(patch);
     });
 
-    editor.on('patch:redo', ({ patch }) => {
+    editor.on('patch:undo', (ev) => {
+      const patch = getPatch(ev);
+      console.log('[Collab] local patch:undo', patch);
+
+      if (!patch) return;
       if (this.isApplyingRemote) return;
+
+      this._broadcastPatch(patch);
+    });
+
+    editor.on('patch:redo', (ev) => {
+      const patch = getPatch(ev);
+      console.log('[Collab] local patch:redo', patch);
+
+      if (!patch) return;
+      if (this.isApplyingRemote) return;
+
       this._broadcastPatch(patch);
     });
   }
 
-  _broadcastPatch(patches) {
+  _broadcastPatch(patch) {
     this.patchSeq += 1;
     const message = {
       type: 'patch',
       clientId: this.options.clientId,
       patchSeq: this.patchSeq,
-      patches,
+      patches: patch, // поле можно оставить "patches" для совместимости, но внутри это PatchProps
     };
 
-    for (const [, peer] of this.peers.entries()) {
+    console.log('[Collab] broadcast patch', message);
+
+    for (const [peerId, peer] of this.peers.entries()) {
+      console.log('[Collab]   peer', peerId, 'dc state:', peer.dc && peer.dc.readyState);
       if (peer.dc && peer.dc.readyState === 'open') {
-        peer.dc.send(JSON.stringify(message));
+        this._sendData(peer.dc, message);
       }
     }
   }
 
   // === ВАЖНО: адаптируй к своему PatchManager API ===
-  applyRemotePatch(patches, meta = {}) {
+  // Применение удалённого патча через ваш PatchManager
+  applyRemotePatch(patch, meta = {}) {
+    console.log('[Collab] applyRemotePatch', patch, meta);
+
     this.isApplyingRemote = true;
     try {
-      const pm = this.editor.PatchManager || this.editor.PatchModule || this.editor.Patch;
-      if (pm && typeof pm.applyPatches === 'function') {
-        pm.applyPatches(patches, { remote: true, ...meta });
-      } else if (pm && typeof pm.applyPatch === 'function') {
-        pm.applyPatch(patches, { remote: true, ...meta });
-      } else {
-        // fallback: если у тебя есть кастомный API, просто вызови его
-        console.warn('[Collab] No PatchManager.apply* found, implement here');
+      const editor = this.editor;
+      const pm = editor.Patches || (editor.get && editor.get('Patches'));
+
+      if (!pm || typeof pm.apply !== 'function') {
+        console.warn('[Collab] PatchManager not found or has no .apply()', pm);
+        return;
       }
+
+      // patch здесь — это PatchProps, ровно тот формат, который генерит ваш PatchManager
+      pm.apply(patch);
     } finally {
       this.isApplyingRemote = false;
     }

--- a/packages/core/index.html
+++ b/packages/core/index.html
@@ -150,10 +150,6 @@
         },
       });
 
-      editor.on('patch:update', ({ patch }) => console.log('patch:update', patch));
-      editor.on('patch:undo', ({ patch }) => console.log('patch:undo', patch));
-      editor.on('patch:redo', ({ patch }) => console.log('patch:redo', patch));
-
       editor.BlockManager.add('testBlock', {
         label: 'Block',
         attributes: { class: 'gjs-fonts gjs-f-b1' },

--- a/packages/core/index.html
+++ b/packages/core/index.html
@@ -150,6 +150,10 @@
         },
       });
 
+      editor.on('patch:update', ({ patch }) => console.log('patch:update', patch));
+      editor.on('patch:undo', ({ patch }) => console.log('patch:undo', patch));
+      editor.on('patch:redo', ({ patch }) => console.log('patch:redo', patch));
+
       editor.BlockManager.add('testBlock', {
         label: 'Block',
         attributes: { class: 'gjs-fonts gjs-f-b1' },

--- a/packages/core/p2p_demo.html
+++ b/packages/core/p2p_demo.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>GrapesJS</title>
+    <link rel="stylesheet" href="dist/css/grapes.min.css" />
+    <script src="grapes.min.js"></script>
+    <!-- 🔹 добавляем наш CollaborativeManager -->
+    <script src="demo-p2p/collaborative-manager.js"></script>
+    <style>
+      body,
+      html {
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="gjs" style="height: 0px; overflow: hidden">
+      <div class="panel">
+        <h1 class="welcome">Welcome to</h1>
+        <div class="big-title">
+          <svg class="logo" viewBox="0 0 100 100">
+            <path
+              d="M40 5l-12.9 7.4 -12.9 7.4c-1.4 0.8-2.7 2.3-3.7 3.9 -0.9 1.6-1.5 3.5-1.5 5.1v14.9 14.9c0 1.7 0.6 3.5 1.5 5.1 0.9 1.6 2.2 3.1 3.7 3.9l12.9 7.4 12.9 7.4c1.4 0.8 3.3 1.2 5.2 1.2 1.9 0 3.8-0.4 5.2-1.2l12.9-7.4 12.9-7.4c1.4-0.8 2.7-2.2 3.7-3.9 0.9-1.6 1.5-3.5 1.5-5.1v-14.9 -12.7c0-4.6-3.8-6-6.8-4.2l-28 16.2"
+            />
+          </svg>
+          <span>GrapesJS</span>
+        </div>
+        <div class="description">
+          This is a demo content from index.html. For the development, you shouldn't edit this file, instead you can
+          copy and rename it to _index.html, on next server start the new file will be served, and it will be ignored by
+          git.
+        </div>
+      </div>
+      <style>
+        .panel {
+          width: 90%;
+          max-width: 700px;
+          border-radius: 3px;
+          padding: 30px 20px;
+          margin: 150px auto 0px;
+          background-color: #d983a6;
+          box-shadow: 0px 3px 10px 0px rgba(0, 0, 0, 0.25);
+          color: rgba(255, 255, 255, 0.75);
+          font: caption;
+          font-weight: 100;
+        }
+
+        .welcome {
+          text-align: center;
+          font-weight: 100;
+          margin: 0px;
+        }
+
+        .logo {
+          width: 70px;
+          height: 70px;
+          vertical-align: middle;
+        }
+
+        .logo path {
+          pointer-events: none;
+          fill: none;
+          stroke-linecap: round;
+          stroke-width: 7;
+          stroke: #fff;
+        }
+
+        .big-title {
+          text-align: center;
+          font-size: 3.5rem;
+          margin: 15px 0;
+        }
+
+        .description {
+          text-align: justify;
+          font-size: 1rem;
+          line-height: 1.5rem;
+        }
+      </style>
+    </div>
+
+    <script type="text/javascript">
+      // Инициализация GrapesJS
+      var editor = grapesjs.init({
+        showOffsets: 1,
+        noticeOnUnload: 0,
+        container: '#gjs',
+        height: '100%',
+        fromElement: true,
+        storageManager: { autoload: 0 },
+        styleManager: {
+          sectors: [
+            {
+              name: 'General',
+              open: false,
+              buildProps: ['float', 'display', 'position', 'top', 'right', 'left', 'bottom'],
+            },
+            {
+              name: 'Flex',
+              open: false,
+              buildProps: [
+                'flex-direction',
+                'flex-wrap',
+                'justify-content',
+                'align-items',
+                'align-content',
+                'order',
+                'flex-basis',
+                'flex-grow',
+                'flex-shrink',
+                'align-self',
+              ],
+            },
+            {
+              name: 'Dimension',
+              open: false,
+              buildProps: ['width', 'height', 'max-width', 'min-height', 'margin', 'padding'],
+            },
+            {
+              name: 'Typography',
+              open: false,
+              buildProps: [
+                'font-family',
+                'font-size',
+                'font-weight',
+                'letter-spacing',
+                'color',
+                'line-height',
+                'text-shadow',
+              ],
+            },
+            {
+              name: 'Decorations',
+              open: false,
+              buildProps: [
+                'border-radius-c',
+                'background-color',
+                'border-radius',
+                'border',
+                'box-shadow',
+                'background',
+              ],
+            },
+            {
+              name: 'Extra',
+              open: false,
+              buildProps: ['transition', 'perspective', 'transform'],
+            },
+          ],
+        },
+      });
+
+      // Логи для дебага patch-событий
+      editor.on('patch:update', ({ patch, patches }) => console.log('patch:update', patch || patches));
+      editor.on('patch:undo', ({ patch }) => console.log('patch:undo', patch));
+      editor.on('patch:redo', ({ patch }) => console.log('patch:redo', patch));
+
+      editor.BlockManager.add('testBlock', {
+        label: 'Block',
+        attributes: { class: 'gjs-fonts gjs-f-b1' },
+        content: `<div style="padding-top:50px; padding-bottom:50px; text-align:center">Test block</div>`,
+      });
+
+      // 🔹 Инициализируем P2P-коллаборацию через CollaborativeManager
+      const roomId = 'demo-room'; // можешь брать из query (?roomId=...)
+      const clientId = 'client-' + Math.random().toString(36).slice(2);
+
+      // если collaborative-manager.js кладёт класс в window.CollaborativeManager:
+      const collab = new CollaborativeManager(editor, {
+        signalingUrl: 'ws://localhost:3001', // адрес твоего signaling-server
+        roomId,
+        clientId,
+        enable: true,
+      });
+
+      // для удобного дебага в консоли
+      window.editor = editor;
+      window.collab = collab;
+    </script>
+  </body>
+</html>

--- a/packages/core/p2p_demo.html
+++ b/packages/core/p2p_demo.html
@@ -153,11 +153,6 @@
         },
       });
 
-      // Логи для дебага patch-событий
-      editor.on('patch:update', ({ patch, patches }) => console.log('patch:update', patch || patches));
-      editor.on('patch:undo', ({ patch }) => console.log('patch:undo', patch));
-      editor.on('patch:redo', ({ patch }) => console.log('patch:redo', patch));
-
       editor.BlockManager.add('testBlock', {
         label: 'Block',
         attributes: { class: 'gjs-fonts gjs-f-b1' },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,9 @@
     "backbone-undo": "0.2.6",
     "codemirror": "5.63.0",
     "codemirror-formatting": "1.0.0",
+    "fractional-indexing": "^3.2.0",
     "html-entities": "~1.4.0",
+    "immer": "^10.2.0",
     "promise-polyfill": "8.3.0",
     "underscore": "1.13.1"
   },

--- a/packages/core/src/css_composer/model/CssRule.ts
+++ b/packages/core/src/css_composer/model/CssRule.ts
@@ -7,6 +7,7 @@ import { isEmptyObj, hasWin } from '../../utils/mixins';
 import Selector, { SelectorProps } from '../../selector_manager/model/Selector';
 import EditorModel from '../../editor/model/Editor';
 import CssRuleView from '../view/CssRuleView';
+import { createId } from '../../utils/mixins';
 
 export interface ToCssOptions {
   important?: boolean | string[];
@@ -17,6 +18,10 @@ export interface ToCssOptions {
 
 /** @private */
 export interface CssRuleProperties extends ObjectHash {
+  /**
+   * Persisted identifier used across collaborative sessions.
+   */
+  id?: string;
   /**
    * Array of selectors
    */
@@ -124,9 +129,26 @@ export default class CssRule extends StyleableModel<CssRuleProperties> {
     this.config = props || {};
     this.opt = opt;
     this.em = opt.em;
+    this.ensureId(props);
     this.ensureSelectors(null, null, {});
     this.setStyle(this.get('style'), { skipWatcherUpdates: true });
     this.on('change', this.__onChange);
+  }
+
+  private ensureId(props?: CssRuleProperties) {
+    const idAttr = (this as any).idAttribute || 'id';
+    const existing = (props && props.id) || (this as any).id || this.get(idAttr);
+    const ruleId = existing || createId();
+
+    if (!this.get(idAttr)) {
+      this.set(idAttr, ruleId, { silent: true });
+    }
+
+    if (!(this as any).id) {
+      (this as any).id = ruleId;
+    }
+
+    return ruleId;
   }
 
   __onChange(rule: CssRule, options: any) {

--- a/packages/core/src/dom_components/model/Components.ts
+++ b/packages/core/src/dom_components/model/Components.ts
@@ -213,7 +213,14 @@ Component> {
         });
         removed.removed();
         removed.trigger('removed');
-        em.trigger(ComponentsEvents.remove, removed);
+        const collection = coll || removed.prevColl || this;
+        const eventOpts = { ...opts, collection };
+        if (typeof eventOpts.index !== 'number') {
+          const prevModels = (opts.previousModels || []) as Component[];
+          const idx = prevModels.indexOf(removed);
+          eventOpts.index = idx >= 0 ? idx : collection?.indexOf?.(removed);
+        }
+        em.trigger(ComponentsEvents.remove, removed, eventOpts);
 
         if (domc && isSymbolInstance(removed) && isSymbolRoot(removed)) {
           domc.symbols.__trgEvent(domc.events.symbolInstanceRemove, { component: removed }, true);
@@ -397,7 +404,7 @@ Component> {
     return model;
   }
 
-  onAdd(model: Component, c?: any, opts: { temporary?: boolean } = {}) {
+  onAdd(model: Component, c?: any, opts: { temporary?: boolean; at?: number } = {}) {
     const { domc, em } = this;
     const avoidInline = em.config.avoidInlineStyle;
     domc && domc.Component.ensureInList(model);
@@ -417,7 +424,10 @@ Component> {
 
     if (em && !opts.temporary) {
       const triggerAdd = (model: Component) => {
-        em.trigger(ComponentsEvents.add, model, opts);
+        const coll = model.collection || model.parent()?.components() || c;
+        const at = typeof opts.at === 'number' && coll === c ? opts.at : coll?.indexOf?.(model);
+        const eventOpts = { ...opts, at, collection: coll };
+        em.trigger(ComponentsEvents.add, model, eventOpts);
         model.components().forEach((comp) => triggerAdd(comp));
       };
       triggerAdd(model);

--- a/packages/core/src/editor/config/config.ts
+++ b/packages/core/src/editor/config/config.ts
@@ -15,6 +15,7 @@ import { RichTextEditorConfig } from '../../rich_text_editor/config/config';
 import { SelectorManagerConfig } from '../../selector_manager/config/config';
 import { StorageManagerConfig } from '../../storage_manager/config/config';
 import { UndoManagerConfig } from '../../undo_manager/config';
+import { PatchManagerConfig } from '../../patch_manager/types';
 import { Plugin } from '../../plugin_manager';
 import { TraitManagerConfig } from '../../trait_manager/config/config';
 import { CommandsConfig } from '../../commands/config/config';
@@ -307,6 +308,11 @@ export interface EditorConfig {
   undoManager?: UndoManagerConfig | boolean;
 
   /**
+   * Configurations for Patches manager
+   */
+  patches?: PatchManagerConfig | boolean;
+
+  /**
    * Configurations for Asset Manager.
    */
   assetManager?: AssetManagerConfig;
@@ -486,6 +492,7 @@ const config: () => EditorConfig = () => ({
   },
   i18n: {},
   undoManager: {},
+  patches: {},
   assetManager: {},
   canvas: {},
   layerManager: {},

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -75,6 +75,7 @@ import StorageManager, { ProjectData, StorageOptions } from '../storage_manager'
 import StyleManager from '../style_manager';
 import TraitManager from '../trait_manager';
 import UndoManagerModule from '../undo_manager';
+import PatchManager from '../patch_manager';
 import UtilsModule from '../utils';
 import html from '../utils/html';
 import defConfig, { EditorConfig, EditorConfigKeys } from './config/config';
@@ -151,6 +152,9 @@ export default class Editor implements IBaseModule<EditorConfig> {
   }
   get UndoManager(): UndoManagerModule {
     return this.em.UndoManager;
+  }
+  get Patches(): PatchManager {
+    return this.em.Patches;
   }
   get RichTextEditor(): RichTextEditorModule {
     return this.em.RichTextEditor;

--- a/packages/core/src/editor/model/Editor.ts
+++ b/packages/core/src/editor/model/Editor.ts
@@ -43,6 +43,7 @@ import { AddComponentsOption, ComponentAdd, DragMode } from '../../dom_component
 import ComponentWrapper from '../../dom_components/model/ComponentWrapper';
 import { CanvasSpotBuiltInTypes } from '../../canvas/model/CanvasSpot';
 import DataSourceManager from '../../data_sources';
+import PatchManager from '../../patch_manager';
 import { ComponentsEvents } from '../../dom_components/types';
 import { InitEditorConfig } from '../..';
 import { EditorEvents, SelectComponentOptions } from '../types';
@@ -54,6 +55,7 @@ const deps: (new (em: EditorModel) => IModule)[] = [
   I18nModule,
   KeymapsModule,
   UndoManagerModule,
+  PatchManager,
   StorageManager,
   DeviceManager,
   ParserModule,
@@ -240,6 +242,10 @@ export default class EditorModel extends Model {
 
   get DataSources(): DataSourceManager {
     return this.get('DataSources');
+  }
+
+  get Patches(): PatchManager {
+    return this.get('Patches');
   }
 
   constructor(conf: EditorConfig = {}) {
@@ -480,6 +486,8 @@ export default class EditorModel extends Model {
   }
 
   changesUp(opts: any, data: Record<string, any>) {
+    if (this.__skip) return;
+    this.Patches?.handleChange(data, opts);
     this.handleUpdates(opts, data);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,5 +159,7 @@ export type {
   DataConditionProps,
   ExpressionProps,
 } from './data_sources/model/conditional_variables/DataCondition';
+export type { default as PatchManager } from './patch_manager';
+export type { PatchProps, PatchManagerConfig, JsonPatch } from './patch_manager/types';
 
 export default grapesjs;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,6 +160,13 @@ export type {
   ExpressionProps,
 } from './data_sources/model/conditional_variables/DataCondition';
 export type { default as PatchManager } from './patch_manager';
-export type { PatchProps, PatchManagerConfig, JsonPatch } from './patch_manager/types';
+export type {
+  PatchProps,
+  PatchManagerConfig,
+  JsonPatch,
+  PatchAdapter,
+  PatchAdapterEvent,
+  PatchAdapterChange,
+} from './patch_manager/types';
 
 export default grapesjs;

--- a/packages/core/src/patch_manager/index.ts
+++ b/packages/core/src/patch_manager/index.ts
@@ -13,6 +13,7 @@ import { createId } from '../utils/mixins';
 import { enablePatches, produceWithPatches } from 'immer';
 import Asset from '../asset_manager/model/Asset';
 import Page from '../pages/model/Page';
+import Selector from '../selector_manager/model/Selector';
 import type {
   JsonPatch,
   PatchAdapter,
@@ -44,6 +45,7 @@ export default class PatchManager extends ItemManagerModule {
   private trackingBound = false;
   private fractionalGen?: (a: string | null, b: string | null) => string;
   private dataRecordAdapter?: PatchAdapter<DataRecord>;
+  private cssRulesBound = false;
 
   private internalSetOptions = {
     fromUndo: true,
@@ -82,6 +84,7 @@ export default class PatchManager extends ItemManagerModule {
     this.registerAdapter(this.createDataSourceAdapter());
     this.registerAdapter(this.createAssetAdapter());
     this.registerAdapter(this.createPageAdapter());
+    this.registerAdapter(this.createSelectorAdapter());
   }
 
   registerAdapter<T>(adapter: PatchAdapter<T>) {
@@ -309,10 +312,17 @@ export default class PatchManager extends ItemManagerModule {
         {
           event: 'add',
           target: () => this.getCssRules(),
-          handler: ({ args }) => {
-            this.ensureCssRuleId(args[0] as CssRule);
-          },
-          skipTrackingCheck: true,
+          handler: ({ args }) => this.handleCssRuleAdd(args[0] as CssRule),
+        },
+        {
+          event: 'remove',
+          target: () => this.getCssRules(),
+          handler: ({ args }) => this.buildAddRemovePatch('cssRule', args[0] as CssRule, 'remove'),
+        },
+        {
+          event: 'change',
+          target: () => this.getCssRules(),
+          handler: ({ args }) => this.handleGenericModelChange(args[0] as CssRule, 'cssRule'),
         },
       ],
       onReady: () => this.ensureAllCssRuleIds(),
@@ -367,12 +377,12 @@ export default class PatchManager extends ItemManagerModule {
         {
           event: 'add',
           target: () => this.getAssets(),
-          handler: ({ args }) => this.buildAddRemovePatch('asset', args[0] as Asset, 'add'),
+          handler: ({ args }) => this.handleAddRemoveCollect('asset', args[0] as Asset, 'add'),
         },
         {
           event: 'remove',
           target: () => this.getAssets(),
-          handler: ({ args }) => this.buildAddRemovePatch('asset', args[0] as Asset, 'remove'),
+          handler: ({ args }) => this.handleAddRemoveCollect('asset', args[0] as Asset, 'remove'),
         },
         {
           event: 'change',
@@ -392,17 +402,42 @@ export default class PatchManager extends ItemManagerModule {
         {
           event: 'add',
           target: () => this.getPages(),
-          handler: ({ args }) => this.buildAddRemovePatch('page', args[0] as Page, 'add'),
+          handler: ({ args }) => this.handleAddRemoveCollect('page', args[0] as Page, 'add'),
         },
         {
           event: 'remove',
           target: () => this.getPages(),
-          handler: ({ args }) => this.buildAddRemovePatch('page', args[0] as Page, 'remove'),
+          handler: ({ args }) => this.handleAddRemoveCollect('page', args[0] as Page, 'remove'),
         },
         {
           event: 'change',
           target: () => this.getPages(),
           handler: ({ args }) => this.handleGenericModelChange(args[0] as Page, 'page'),
+        },
+      ],
+    };
+  }
+
+  private createSelectorAdapter(): PatchAdapter<Selector> {
+    return {
+      type: 'selector',
+      getId: (sel) => (sel as any).id || (sel as any).get?.('id') || (sel as any).getFullName?.() || sel.cid,
+      resolve: (em, id) => em.Selectors?.get(id),
+      events: [
+        {
+          event: 'add',
+          target: () => this.getSelectors(),
+          handler: ({ args }) => this.handleAddRemoveCollect('selector', args[0] as Selector, 'add'),
+        },
+        {
+          event: 'remove',
+          target: () => this.getSelectors(),
+          handler: ({ args }) => this.handleAddRemoveCollect('selector', args[0] as Selector, 'remove'),
+        },
+        {
+          event: 'change',
+          target: () => this.getSelectors(),
+          handler: ({ args }) => this.handleGenericModelChange(args[0] as Selector, 'selector'),
         },
       ],
     };
@@ -456,6 +491,12 @@ export default class PatchManager extends ItemManagerModule {
     return { patches: [patch], inverse: [inverse] };
   }
 
+  private handleAddRemoveCollect(type: string, model: any, op: 'add' | 'remove') {
+    const res = this.buildAddRemovePatch(type, model, op);
+    res && this.collect(res.patches, res.inverse || []);
+    return res;
+  }
+
   private handleGenericModelChange(model: any, adapterType: string) {
     const adapter = this.adapters.get(adapterType);
     if (!adapter) return;
@@ -484,6 +525,8 @@ export default class PatchManager extends ItemManagerModule {
     const supportsFractional = this.supportsFractionalIndexing(coll);
 
     if (supportsFractional) {
+      const existing = this.getExistingFractionalKey(coll, cmp);
+      if (existing) return existing;
       const key = this.buildFractionalKey(coll, typeof at === 'number' ? at : cmp ? coll.indexOf(cmp) : undefined);
       if (key) return key;
     }
@@ -550,13 +593,22 @@ export default class PatchManager extends ItemManagerModule {
     return this.em.Pages?.getAll?.();
   }
 
+  private getSelectors() {
+    return this.em.Selectors?.getAll?.();
+  }
+
   private bindAllDataSourceRecords() {
     const dss = this.getDataSources();
     if (!dss) return;
     dss.each((ds: DataSource) => this.bindDataSourceRecords(ds));
     if (dss.on) {
       dss.on('add', this.bindDataSourceRecords);
-      this.adapterListeners.push({ adapter: 'dataRecord', target: dss, event: 'add', handler: this.bindDataSourceRecords });
+      this.adapterListeners.push({
+        adapter: 'dataRecord',
+        target: dss,
+        event: 'add',
+        handler: this.bindDataSourceRecords,
+      });
     }
   }
 
@@ -823,6 +875,8 @@ export default class PatchManager extends ItemManagerModule {
 
   private findComponentByKey(coll: any, key: string) {
     if (!coll) return null;
+    const byId = coll.getById?.(key) || coll.get?.(key);
+    if (byId) return byId;
     if (typeof coll.findByFractionalKey === 'function' && isNaN(Number(key))) {
       return coll.findByFractionalKey(key);
     }
@@ -853,15 +907,19 @@ export default class PatchManager extends ItemManagerModule {
     const fromColl = this.getComponentsCollection(fromTarget);
     if (!fromColl) return false;
 
+    return this.applyComponentsMoveWithKeys(fromColl, fromKey, coll, key);
+  }
+
+  private applyComponentsMoveWithKeys(fromColl: any, fromKey: string, toColl: any, toKey: string) {
     const model = this.findComponentByKey(fromColl, fromKey);
     if (!model) return false;
 
     fromColl.remove(model, { ...this.internalSetOptions, temporary: true });
 
-    const at = this.resolveComponentIndex(coll, key);
-    const added = coll.add(model, { ...this.internalSetOptions, at });
+    const at = this.resolveComponentIndex(toColl, toKey);
+    const added = toColl.add(model, { ...this.internalSetOptions, at });
     const list = Array.isArray(added) ? added : [added];
-    list.forEach((m) => this.setFractionalKey(coll, m, key));
+    list.forEach((m) => this.setFractionalKey(toColl, m, toKey));
     return true;
   }
 
@@ -893,6 +951,10 @@ export default class PatchManager extends ItemManagerModule {
   private getCssRules() {
     if (!this.cssRules) {
       this.cssRules = this.em.Css?.getAll?.();
+      if (this.cssRules && !this.cssRulesBound) {
+        this.cssRules.on('add', this.handleCssRuleAdd);
+        this.cssRulesBound = true;
+      }
     }
     return this.cssRules;
   }
@@ -900,6 +962,12 @@ export default class PatchManager extends ItemManagerModule {
   private ensureAllCssRuleIds() {
     this.getCssRules()?.each((rule: CssRule) => this.ensureCssRuleId(rule));
   }
+
+  private handleCssRuleAdd = (rule: CssRule) => {
+    this.ensureCssRuleId(rule);
+    const res = this.buildAddRemovePatch('cssRule', rule, 'add');
+    res && this.collect(res.patches, res.inverse || []);
+  };
 
   private isBlockedKey(key?: string, adapter?: PatchAdapter<any>) {
     if (!key) return false;
@@ -971,7 +1039,18 @@ export default class PatchManager extends ItemManagerModule {
     delete ref[path[path.length - 1]];
   }
 
-  private handleMove(_target: any, _seg: string[], _p: JsonPatch) {}
+  private handleMove(target: any, seg: string[], p: JsonPatch) {
+    const [fromType, fromId, fromLabel, fromKey] = (p.from || '').split('/').filter(Boolean);
+    const [, , toLabel, toKey] = seg;
+
+    if (fromLabel === 'components' && toLabel === 'components') {
+      const toColl = this.getComponentsCollection(target);
+      const fromTarget = this.resolveTarget(fromType, fromId);
+      const fromColl = this.getComponentsCollection(fromTarget);
+      if (!toColl || !fromColl) return;
+      this.applyComponentsMoveWithKeys(fromColl, fromKey, toColl, toKey);
+    }
+  }
 
   destroy(): void {
     this.unbindAllAdapters();

--- a/packages/core/src/patch_manager/index.ts
+++ b/packages/core/src/patch_manager/index.ts
@@ -1,4 +1,6 @@
 import Component from '../dom_components/model/Component';
+import DataSource from '../data_sources/model/DataSource';
+import DataRecord from '../data_sources/model/DataRecord';
 import Components from '../dom_components/model/Components';
 import { ComponentsEvents } from '../dom_components/types';
 import CssRule from '../css_composer/model/CssRule';
@@ -9,6 +11,8 @@ import EditorModel from '../editor/model/Editor';
 import { EditorEvents } from '../editor/types';
 import { createId } from '../utils/mixins';
 import { enablePatches, produceWithPatches } from 'immer';
+import Asset from '../asset_manager/model/Asset';
+import Page from '../pages/model/Page';
 import type {
   JsonPatch,
   PatchAdapter,
@@ -39,6 +43,7 @@ export default class PatchManager extends ItemManagerModule {
   private adapterListeners: { adapter: string; target: any; event: string; handler: (...args: any[]) => void }[] = [];
   private trackingBound = false;
   private fractionalGen?: (a: string | null, b: string | null) => string;
+  private dataRecordAdapter?: PatchAdapter<DataRecord>;
 
   private internalSetOptions = {
     fromUndo: true,
@@ -72,6 +77,11 @@ export default class PatchManager extends ItemManagerModule {
   private registerDefaultAdapters() {
     this.registerAdapter(this.createComponentAdapter());
     this.registerAdapter(this.createCssRuleAdapter());
+    this.dataRecordAdapter = this.createDataRecordAdapter();
+    this.registerAdapter(this.dataRecordAdapter);
+    this.registerAdapter(this.createDataSourceAdapter());
+    this.registerAdapter(this.createAssetAdapter());
+    this.registerAdapter(this.createPageAdapter());
   }
 
   registerAdapter<T>(adapter: PatchAdapter<T>) {
@@ -309,6 +319,95 @@ export default class PatchManager extends ItemManagerModule {
     };
   }
 
+  private createDataRecordAdapter(): PatchAdapter<DataRecord> {
+    return {
+      type: 'dataRecord',
+      getId: (record) => this.buildDataRecordId(record),
+      resolve: (em, id) => {
+        const [dsId, recId] = id.split('::');
+        const ds = em.DataSources?.get(dsId);
+        return ds?.records?.get(recId) || null;
+      },
+    };
+  }
+
+  private createDataSourceAdapter(): PatchAdapter<DataSource> {
+    return {
+      type: 'dataSource',
+      sourceKeys: ['dataSource'],
+      getId: (ds) => `${ds.id || ds.cid}`,
+      resolve: (em, id) => em.DataSources?.get(id),
+      events: [
+        {
+          event: 'add',
+          target: () => this.getDataSources(),
+          handler: ({ args }) => this.handleDataSourceAdd(args[0] as DataSource),
+        },
+        {
+          event: 'remove',
+          target: () => this.getDataSources(),
+          handler: ({ args }) => this.handleDataSourceRemove(args[0] as DataSource),
+        },
+        {
+          event: 'change',
+          target: () => this.getDataSources(),
+          handler: ({ args }) => this.handleGenericModelChange(args[0] as DataSource, 'dataSource'),
+        },
+      ],
+      onReady: () => this.bindAllDataSourceRecords(),
+    };
+  }
+
+  private createAssetAdapter(): PatchAdapter<Asset> {
+    return {
+      type: 'asset',
+      getId: (asset) => (asset.get ? asset.get('src') : (asset as any).src),
+      resolve: (em, id) => em.Assets?.get(id),
+      events: [
+        {
+          event: 'add',
+          target: () => this.getAssets(),
+          handler: ({ args }) => this.buildAddRemovePatch('asset', args[0] as Asset, 'add'),
+        },
+        {
+          event: 'remove',
+          target: () => this.getAssets(),
+          handler: ({ args }) => this.buildAddRemovePatch('asset', args[0] as Asset, 'remove'),
+        },
+        {
+          event: 'change',
+          target: () => this.getAssets(),
+          handler: ({ args }) => this.handleGenericModelChange(args[0] as Asset, 'asset'),
+        },
+      ],
+    };
+  }
+
+  private createPageAdapter(): PatchAdapter<Page> {
+    return {
+      type: 'page',
+      getId: (page) => `${(page as any).id || page.get('id') || page.cid}`,
+      resolve: (em, id) => em.Pages?.get(id),
+      events: [
+        {
+          event: 'add',
+          target: () => this.getPages(),
+          handler: ({ args }) => this.buildAddRemovePatch('page', args[0] as Page, 'add'),
+        },
+        {
+          event: 'remove',
+          target: () => this.getPages(),
+          handler: ({ args }) => this.buildAddRemovePatch('page', args[0] as Page, 'remove'),
+        },
+        {
+          event: 'change',
+          target: () => this.getPages(),
+          handler: ({ args }) => this.handleGenericModelChange(args[0] as Page, 'page'),
+        },
+      ],
+    };
+  }
+
   private cloneValue(value: any) {
     if (typeof value === 'undefined') return value;
     try {
@@ -341,6 +440,37 @@ export default class PatchManager extends ItemManagerModule {
         return patch.op === 'remove' ? { op: patch.op, path: fullPath } : { op: patch.op, path: fullPath, value };
       })
       .filter(Boolean) as JsonPatch[];
+  }
+
+  private buildAddRemovePatch(type: string, model: any, op: 'add' | 'remove') {
+    if (!model) return;
+    const adapter = this.adapters.get(type);
+    if (!adapter) return;
+    const id = adapter.getId(model);
+    if (!id) return;
+    const path = this.buildPath(type, `${id}`);
+    const value = this.cloneValue(model.toJSON?.() || model);
+    const patch: JsonPatch = op === 'add' ? { op: 'add', path, value } : { op: 'remove', path };
+    const inverse: JsonPatch =
+      op === 'add' ? { op: 'remove', path } : { op: 'add', path, value: this.cloneValue(model.toJSON?.() || model) };
+    return { patches: [patch], inverse: [inverse] };
+  }
+
+  private handleGenericModelChange(model: any, adapterType: string) {
+    const adapter = this.adapters.get(adapterType);
+    if (!adapter) return;
+    const changed = typeof model.changedAttributes === 'function' ? model.changedAttributes() : null;
+    if (!changed || !Object.keys(changed).length) return;
+    const patches: JsonPatch[] = [];
+    const inverse: JsonPatch[] = [];
+    this.handleAdapterChange(adapter, { target: model, changed }, patches, inverse);
+    return { patches, inverse };
+  }
+
+  private buildDataRecordId(record: DataRecord) {
+    const dsId = (record as any).dataSource?.id || (record as any).dataSource?.cid || 'ds';
+    const recId = record.id || (record as any).cid;
+    return `${dsId}::${recId}`;
   }
 
   private buildPath(type: string, id: string, segments: (string | number)[] = []) {
@@ -407,6 +537,67 @@ export default class PatchManager extends ItemManagerModule {
       typeof model?.set === 'function' && model.set('fractionalKey', key, this.internalSetOptions);
     }
   }
+
+  private getDataSources() {
+    return this.em.DataSources?.all || this.em.DataSources?.getAll?.();
+  }
+
+  private getAssets() {
+    return this.em.Assets?.getAll?.();
+  }
+
+  private getPages() {
+    return this.em.Pages?.getAll?.();
+  }
+
+  private bindAllDataSourceRecords() {
+    const dss = this.getDataSources();
+    if (!dss) return;
+    dss.each((ds: DataSource) => this.bindDataSourceRecords(ds));
+    if (dss.on) {
+      dss.on('add', this.bindDataSourceRecords);
+      this.adapterListeners.push({ adapter: 'dataRecord', target: dss, event: 'add', handler: this.bindDataSourceRecords });
+    }
+  }
+
+  private bindDataSourceRecords = (ds: DataSource) => {
+    if (!ds?.records) return;
+    const recs = ds.records;
+    const bind = (event: string, handler: (...args: any[]) => void) => {
+      recs.on(event, handler);
+      this.adapterListeners.push({ adapter: 'dataRecord', target: recs, event, handler });
+    };
+    bind('add', (record: DataRecord) => {
+      const patch = this.buildAddRemovePatch('dataRecord', record, 'add');
+      patch && this.collect(patch.patches, patch.inverse || []);
+    });
+    bind('remove', (record: DataRecord) => {
+      const patch = this.buildAddRemovePatch('dataRecord', record, 'remove');
+      patch && this.collect(patch.patches, patch.inverse || []);
+    });
+    bind('change', (record: DataRecord) => {
+      const res = this.handleGenericModelChange(record, 'dataRecord');
+      res && this.collect(res.patches, res.inverse || []);
+    });
+  };
+
+  private unbindDataSourceRecords(ds: DataSource) {
+    if (!ds?.records || !ds.records.off) return;
+    const recs = ds.records;
+    const listeners = this.adapterListeners.filter((item) => item.target === recs);
+    listeners.forEach(({ event, handler }) => recs.off(event, handler));
+    this.adapterListeners = this.adapterListeners.filter((item) => item.target !== recs);
+  }
+
+  private handleDataSourceAdd = (ds: DataSource) => {
+    this.bindDataSourceRecords(ds);
+    return this.buildAddRemovePatch('dataSource', ds, 'add');
+  };
+
+  private handleDataSourceRemove = (ds: DataSource) => {
+    this.unbindDataSourceRecords(ds);
+    return this.buildAddRemovePatch('dataSource', ds, 'remove');
+  };
 
   // Lazy-load fractional-indexing to work in CJS/Jest environments without extra transpilation.
   private getGenerateKeyBetween() {

--- a/packages/core/src/patch_manager/index.ts
+++ b/packages/core/src/patch_manager/index.ts
@@ -2,6 +2,7 @@ import Component from '../dom_components/model/Component';
 import Components from '../dom_components/model/Components';
 import { ComponentsEvents } from '../dom_components/types';
 import CssRule from '../css_composer/model/CssRule';
+import CssRules from '../css_composer/model/CssRules';
 import { ItemManagerModule } from '../abstract/Module';
 import { Collection } from '../common';
 import EditorModel from '../editor/model/Editor';
@@ -16,6 +17,7 @@ export default class PatchManager extends ItemManagerModule {
   isEnabled = false;
   private debug = false;
   private isReady = false;
+  private cssRules?: CssRules;
 
   private history: PatchProps[] = [];
   private index = -1;
@@ -55,6 +57,9 @@ export default class PatchManager extends ItemManagerModule {
 
   private setupTracking() {
     const { em } = this;
+    this.cssRules = em.Css?.getAll?.();
+    this.ensureAllCssRuleIds();
+    this.cssRules?.on('add', this.handleCssRuleAdd);
     this.isReady = !!em.get('readyLoad');
     em.on('change:readyLoad', this.handleReadyLoad);
     em.on(EditorEvents.projectLoad, this.handleProjectLoad);
@@ -65,12 +70,14 @@ export default class PatchManager extends ItemManagerModule {
   private handleReadyLoad = () => {
     if (!this.em.get('readyLoad')) return;
     this.isReady = true;
+    this.ensureAllCssRuleIds();
     this.resetHistory();
     this.em.off('change:readyLoad', this.handleReadyLoad);
   };
 
   private handleProjectLoad = () => {
     this.resetHistory();
+    this.ensureAllCssRuleIds();
   };
 
   handleChange(data: Record<string, any> = {}, opts: Record<string, any> = {}) {
@@ -111,7 +118,8 @@ export default class PatchManager extends ItemManagerModule {
   }
 
   private handleRuleChange(rule: CssRule, changed: Record<string, any>, patches: JsonPatch[], reverse: JsonPatch[]) {
-    const ruleId = (rule as any).id || rule.cid;
+    const ruleId = this.ensureCssRuleId(rule);
+
     Object.keys(changed).forEach((key) => {
       const path = this.buildPath('cssRule', `${ruleId}`, [key]);
       const nextVal = changed[key];
@@ -336,8 +344,19 @@ export default class PatchManager extends ItemManagerModule {
   private applyJsonPatch(p: JsonPatch) {
     const seg = p.path.split('/').filter(Boolean);
     const [objectType, objectId, ...rest] = seg;
-    if (!objectType || !objectId) return;
     const target = this.resolveTarget(objectType, objectId);
+
+    if (this.debug) {
+      console.log('[PatchManager] applyJsonPatch', {
+        p,
+        objectType,
+        objectId,
+        rest,
+        resolved: !!target,
+      });
+    }
+
+    if (!objectType || !objectId) return;
     if (!target) return;
 
     if (rest[0] === 'components' && this.applyComponentsPatch(target, rest.slice(1), p)) {
@@ -446,6 +465,38 @@ export default class PatchManager extends ItemManagerModule {
     }
   }
 
+  private ensureCssRuleId(rule?: CssRule) {
+    if (!rule) return '';
+    const idAttr = (rule as any).idAttribute || 'id';
+    let ruleId = (rule as any).id || (rule as any)[idAttr] || (rule as any).get?.(idAttr);
+
+    if (!ruleId) {
+      ruleId = createId();
+      (rule as any).id = ruleId;
+      typeof (rule as any).set === 'function' && rule.set(idAttr, ruleId, { silent: true });
+    } else if (!(rule as any).id) {
+      (rule as any).id = ruleId;
+    }
+
+    if (this.debug) {
+      console.log('[PatchManager] ensureCssRuleId', ruleId, rule);
+    }
+
+    return ruleId;
+  }
+
+  private handleCssRuleAdd = (rule: CssRule) => {
+    this.ensureCssRuleId(rule);
+  };
+
+  private ensureAllCssRuleIds() {
+    if (!this.cssRules) {
+      this.cssRules = this.em.Css?.getAll?.();
+      this.cssRules?.on('add', this.handleCssRuleAdd);
+    }
+    this.cssRules?.each((rule: CssRule) => this.ensureCssRuleId(rule));
+  }
+
   private isBlockedRootKey(key?: string) {
     if (!key) return false;
     return PatchManager.blockedRootKeys.has(key);
@@ -518,6 +569,7 @@ export default class PatchManager extends ItemManagerModule {
   private handleMove(_target: any, _seg: string[], _p: JsonPatch) {}
 
   destroy(): void {
+    this.cssRules?.off('add', this.handleCssRuleAdd);
     this.em?.off('change:readyLoad', this.handleReadyLoad);
     this.em?.off(EditorEvents.projectLoad, this.handleProjectLoad);
     this.em?.off(ComponentsEvents.add, this.handleComponentAdd);

--- a/packages/core/src/patch_manager/index.ts
+++ b/packages/core/src/patch_manager/index.ts
@@ -1,0 +1,540 @@
+import Component from '../dom_components/model/Component';
+import Components from '../dom_components/model/Components';
+import { ComponentsEvents } from '../dom_components/types';
+import CssRule from '../css_composer/model/CssRule';
+import { ItemManagerModule } from '../abstract/Module';
+import { Collection } from '../common';
+import EditorModel from '../editor/model/Editor';
+import { EditorEvents } from '../editor/types';
+import { createId } from '../utils/mixins';
+import type { JsonPatch, PatchManagerConfig, PatchProps } from './types';
+
+const encodePointer = (segment: string) => segment.replace(/~/g, '~0').replace(/\//g, '~1');
+
+export default class PatchManager extends ItemManagerModule {
+  storageKey = '';
+  isEnabled = false;
+  private debug = false;
+  private isReady = false;
+
+  private history: PatchProps[] = [];
+  private index = -1;
+  private active: PatchProps | null = null;
+  private coalesceTimer?: ReturnType<typeof setTimeout>;
+  private coalesceMs = 0;
+  private maxHistory = 500;
+  private isApplyingExternal = false;
+
+  private internalSetOptions = {
+    fromUndo: true,
+    noUndo: true,
+    avoidStore: true,
+    _skipPatches: true,
+  };
+
+  private static blockedRootKeys = new Set<string>(['traits', '__data_values', 'docEl', 'head', 'toolbar']);
+
+  constructor(em: EditorModel) {
+    super(em, 'Patches', new Collection(), undefined, undefined, { skipListen: true });
+  }
+
+  onInit(): void {
+    const cfg = (this.getConfig() as any) ?? {};
+    const normalized = typeof cfg === 'boolean' ? { enable: cfg } : cfg;
+    this.init({ enable: true, ...normalized });
+    this.setupTracking();
+  }
+
+  init(cfg: PatchManagerConfig = {}) {
+    this.isEnabled = !!cfg.enable;
+    this.maxHistory = cfg.maxHistory ?? this.maxHistory;
+    this.coalesceMs = cfg.coalesceMs ?? 0;
+    this.debug = cfg.debug ?? false;
+    return this;
+  }
+
+  private setupTracking() {
+    const { em } = this;
+    this.isReady = !!em.get('readyLoad');
+    em.on('change:readyLoad', this.handleReadyLoad);
+    em.on(EditorEvents.projectLoad, this.handleProjectLoad);
+    em.on(ComponentsEvents.add, this.handleComponentAdd);
+    em.on(ComponentsEvents.remove, this.handleComponentRemove);
+  }
+
+  private handleReadyLoad = () => {
+    if (!this.em.get('readyLoad')) return;
+    this.isReady = true;
+    this.resetHistory();
+    this.em.off('change:readyLoad', this.handleReadyLoad);
+  };
+
+  private handleProjectLoad = () => {
+    this.resetHistory();
+  };
+
+  handleChange(data: Record<string, any> = {}, opts: Record<string, any> = {}) {
+    if (!this.canTrack() || this.shouldSkipOptions(opts)) return;
+    const patches: JsonPatch[] = [];
+    const reverse: JsonPatch[] = [];
+    const component = data.component as Component | undefined;
+    const changed = data.changed as Record<string, any> | undefined;
+    const rule = data.rule as CssRule | undefined;
+
+    if (component && changed) {
+      this.handleComponentChange(component, changed, patches, reverse);
+    } else if (rule && changed) {
+      this.handleRuleChange(rule, changed, patches, reverse);
+    }
+
+    if (patches.length) {
+      this.collect(patches, reverse);
+    }
+  }
+
+  private handleComponentChange(
+    component: Component,
+    changed: Record<string, any>,
+    patches: JsonPatch[],
+    reverse: JsonPatch[],
+  ) {
+    const compId = component.getId();
+    Object.keys(changed).forEach((key) => {
+      if (this.isBlockedRootKey(key)) return;
+      const path = this.buildPath('component', compId, [key]);
+      const nextVal = changed[key];
+      const prevVal = component.previous ? component.previous(key) : undefined;
+      const { patch, inverse } = this.buildPatchPair(path, prevVal, nextVal);
+      patch && patches.push(patch);
+      inverse && reverse.push(inverse);
+    });
+  }
+
+  private handleRuleChange(rule: CssRule, changed: Record<string, any>, patches: JsonPatch[], reverse: JsonPatch[]) {
+    const ruleId = (rule as any).id || rule.cid;
+    Object.keys(changed).forEach((key) => {
+      const path = this.buildPath('cssRule', `${ruleId}`, [key]);
+      const nextVal = changed[key];
+      const prevVal = rule.previous ? rule.previous(key) : undefined;
+      const { patch, inverse } = this.buildPatchPair(path, prevVal, nextVal);
+      patch && patches.push(patch);
+      inverse && reverse.push(inverse);
+    });
+  }
+
+  private handleComponentAdd = (component: Component, opts: any = {}) => {
+    if (!this.canTrack() || this.shouldSkipOptions(opts)) return;
+    const parent = component.parent();
+    const collection = (component.collection || parent?.components()) as Components | undefined;
+    if (!parent || !collection) return;
+    const at = typeof opts.at === 'number' ? opts.at : collection.indexOf(component);
+    const path = this.buildPath('component', parent.getId(), ['components', this.getComponentKey(collection, component, at)]);
+    const value = this.cloneValue(component.toJSON());
+    const patch: JsonPatch = { op: 'add', path, value };
+    const inverse: JsonPatch = { op: 'remove', path };
+    this.collect([patch], [inverse]);
+  };
+
+  private handleComponentRemove = (component: Component, opts: any = {}) => {
+    if (!this.canTrack() || this.shouldSkipOptions(opts)) return;
+    const collection = (opts.collection || component.prevColl) as Components | undefined;
+    const parent = component.parent({ prev: true });
+    if (!parent || !collection) return;
+    const index = typeof opts.index === 'number' ? opts.index : collection.indexOf(component);
+    const path = this.buildPath('component', parent.getId(), [
+      'components',
+      this.getComponentKey(collection, component, index),
+    ]);
+    const reverseVal = this.cloneValue(component.toJSON());
+    const patch: JsonPatch = { op: 'remove', path };
+    const inverse: JsonPatch = { op: 'add', path, value: reverseVal };
+    this.collect([patch], [inverse]);
+  };
+
+  private cloneValue(value: any) {
+    if (typeof value === 'undefined') return value;
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (err) {
+      return value;
+    }
+  }
+
+  private buildPatchPair(path: string, prevVal: any, nextVal: any) {
+    const op = this.getOp(prevVal, nextVal);
+    const invOp = this.getOp(nextVal, prevVal);
+    const patch = op ? this.buildPatch(op, path, nextVal) : null;
+    const inverse = invOp ? this.buildPatch(invOp, path, prevVal) : null;
+    return { patch, inverse };
+  }
+
+  private buildPatch(op: JsonPatch['op'], path: string, value: any): JsonPatch {
+    const cloned = this.cloneValue(value);
+    return op === 'remove' ? { op, path } : { op, path, value: cloned };
+  }
+
+  private getOp(prevVal: any, nextVal: any): JsonPatch['op'] | null {
+    if (typeof nextVal === 'undefined') return 'remove';
+    return typeof prevVal === 'undefined' ? 'add' : 'replace';
+  }
+
+  private buildPath(type: string, id: string, segments: (string | number)[] = []) {
+    const data = [type, id, ...segments.map((seg) => `${seg}`)];
+    return `/${data.map(encodePointer).join('/')}`;
+  }
+
+  private getComponentKey(coll?: Components, cmp?: Component, at?: number) {
+    const getFractional = (coll as any)?.getFractionalKey;
+    if (typeof getFractional === 'function' && cmp) {
+      return getFractional.call(coll, cmp);
+    }
+    if (typeof at === 'number') {
+      return `${at}`;
+    }
+    const idx = coll && cmp ? coll.indexOf(cmp) : -1;
+    return `${idx >= 0 ? idx : 0}`;
+  }
+
+  private resetHistory() {
+    this.coalesceTimer && clearTimeout(this.coalesceTimer);
+    this.coalesceTimer = undefined;
+    this.active = null;
+    this.history = [];
+    this.index = -1;
+  }
+
+  canTrack() {
+    return this.isEnabled && this.isReady && !this.isApplyingExternal;
+  }
+
+  beginBatch(meta?: Record<string, any>) {
+    if (!this.canTrack()) return;
+    if (!this.active) {
+      this.active = { id: createId(), ts: Date.now(), changes: [], reverseChanges: [], meta };
+      this.em.trigger('patch:batch:start', this.active);
+    }
+  }
+
+  endBatch() {
+    if (!this.canTrack() || !this.active) return;
+    const patch = this.active;
+
+    this.active = null;
+    if (patch.changes.length === 0 && patch.reverseChanges.length === 0) return;
+
+    if (this.index < this.history.length - 1) {
+      this.history = this.history.slice(0, this.index + 1);
+    }
+
+    this.history.push(patch);
+    if (this.history.length > this.maxHistory) {
+      this.history.shift();
+    } else {
+      this.index++;
+    }
+
+    this.em.trigger('patch:update', { patch });
+    if (this.debug) {
+      this.logWithEditor('update', patch);
+    }
+  }
+
+  update(fn: () => void, meta?: Record<string, any>) {
+    if (!this.canTrack()) return fn();
+
+    const alreadyActive = !!this.active;
+
+    if (!alreadyActive) this.beginBatch(meta);
+
+    try {
+      fn();
+    } finally {
+      if (!alreadyActive) {
+        if (this.coalesceMs > 0) {
+          if (this.coalesceTimer) clearTimeout(this.coalesceTimer);
+          this.coalesceTimer = setTimeout(() => this.endBatch(), this.coalesceMs);
+        } else {
+          this.endBatch();
+        }
+      }
+    }
+  }
+
+  collect(changes: JsonPatch[], inverse: JsonPatch[]) {
+    if (!this.canTrack()) return;
+
+    const startedHere = !this.active;
+    if (startedHere) this.beginBatch();
+    this.active!.changes.push(...changes);
+    this.active!.reverseChanges.unshift(...inverse);
+    if (startedHere) {
+      if (this.coalesceMs > 0) {
+        if (this.coalesceTimer) clearTimeout(this.coalesceTimer);
+        this.coalesceTimer = setTimeout(() => this.endBatch(), this.coalesceMs);
+      } else {
+        this.endBatch();
+      }
+    }
+  }
+
+  apply(patch: PatchProps) {
+    if (!this.isEnabled) return;
+    this.isApplyingExternal = true;
+    try {
+      this.applyJsonPatchList(patch.changes);
+      this.em.trigger('patch:applied:external', { patch });
+      if (this.debug) {
+        this.logWithEditor('applied external', patch);
+      }
+    } finally {
+      this.isApplyingExternal = false;
+    }
+  }
+
+  undo() {
+    if (!this.canTrack() || this.index < 0) return;
+    const patch = this.history[this.index];
+
+    this.isApplyingExternal = true;
+    try {
+      this.applyJsonPatchList(patch.reverseChanges);
+    } finally {
+      this.isApplyingExternal = false;
+    }
+    this.index--;
+    this.em.trigger('patch:undo', { patch });
+  }
+
+  redo() {
+    if (!this.canTrack() || this.index >= this.history.length - 1) return;
+    const patch = this.history[this.index + 1];
+    this.isApplyingExternal = true;
+    try {
+      this.applyJsonPatchList(patch.changes);
+    } finally {
+      this.isApplyingExternal = false;
+    }
+    this.index++;
+    this.em.trigger('patch:redo', { patch });
+  }
+
+  private applyJsonPatchList(list: JsonPatch[]) {
+    for (const p of list) {
+      try {
+        this.applyJsonPatch(p);
+      } catch (e) {
+        if (this.debug) {
+          this.logWithEditor('apply error', { patch: p } as any);
+        }
+      }
+    }
+  }
+
+  private applyJsonPatch(p: JsonPatch) {
+    const seg = p.path.split('/').filter(Boolean);
+    const [objectType, objectId, ...rest] = seg;
+    if (!objectType || !objectId) return;
+    const target = this.resolveTarget(objectType, objectId);
+    if (!target) return;
+
+    if (rest[0] === 'components' && this.applyComponentsPatch(target, rest.slice(1), p)) {
+      return;
+    }
+
+    switch (p.op) {
+      case 'add':
+      case 'replace':
+        this.setByPath(target, rest, p.value);
+        break;
+      case 'remove':
+        this.deleteByPath(target, rest);
+        break;
+      case 'move':
+        this.handleMove(target, seg, p);
+        break;
+    }
+  }
+
+  private applyComponentsPatch(target: any, path: string[], patch: JsonPatch) {
+    const coll = this.getComponentsCollection(target);
+    if (!coll) return false;
+    const [key] = path;
+    if (!key) return false;
+
+    switch (patch.op) {
+      case 'remove': {
+        const model = this.findComponentByKey(coll, key);
+        model && coll.remove(model, { ...this.internalSetOptions });
+        return true;
+      }
+      case 'add':
+      case 'replace': {
+        const index = this.resolveComponentIndex(coll, key);
+        const opts = { ...this.internalSetOptions, at: index };
+        const existing = this.findComponentByKey(coll, key);
+        existing && coll.remove(existing, opts);
+        if (patch.value) {
+          const added = coll.add(patch.value as any, opts);
+          const list = Array.isArray(added) ? added : [added];
+          list.forEach((m) => coll.setFractionalKey?.(m, key));
+        }
+        return true;
+      }
+      case 'move': {
+        return this.applyComponentsMove(coll, key, patch);
+      }
+      default:
+        return false;
+    }
+  }
+
+  private getComponentsCollection(target: any) {
+    return typeof target?.components === 'function' ? target.components() : null;
+  }
+
+  private findComponentByKey(coll: any, key: string) {
+    if (!coll) return null;
+    if (typeof coll.findByFractionalKey === 'function') {
+      return coll.findByFractionalKey(key);
+    }
+    const idx = Number(key);
+    return Number.isNaN(idx) ? null : coll.at(idx);
+  }
+
+  private resolveComponentIndex(coll: any, key: string) {
+    if (typeof coll.getIndexFromFractionalKey === 'function') {
+      return coll.getIndexFromFractionalKey(key);
+    }
+    const idx = Number(key);
+    return Number.isNaN(idx) ? coll.length : idx;
+  }
+
+  private applyComponentsMove(coll: any, key: string, patch: JsonPatch) {
+    if (!patch.from) return false;
+    const fromSeg = patch.from.split('/').filter(Boolean);
+    const [fromType, fromId, fromLabel, fromKey] = fromSeg;
+    if (fromLabel !== 'components' || !fromType || !fromId || !fromKey) return false;
+
+    const fromTarget = this.resolveTarget(fromType, fromId);
+    const fromColl = this.getComponentsCollection(fromTarget);
+    if (!fromColl) return false;
+
+    const model = this.findComponentByKey(fromColl, fromKey);
+    if (!model) return false;
+
+    fromColl.remove(model, { ...this.internalSetOptions, temporary: true });
+
+    const at = this.resolveComponentIndex(coll, key);
+    const added = coll.add(model, { ...this.internalSetOptions, at });
+    const list = Array.isArray(added) ? added : [added];
+    list.forEach((m) => coll.setFractionalKey?.(m, key));
+    return true;
+  }
+
+  private resolveTarget(type: string, id: string): any {
+    const { em } = this;
+    switch (type) {
+      case 'component':
+        return em.Components?.getById(id);
+      case 'cssRule':
+        return em.Css?.rules?.get(id) ?? em.Css?.get(id);
+      default:
+        return null;
+    }
+  }
+
+  private isBlockedRootKey(key?: string) {
+    if (!key) return false;
+    return PatchManager.blockedRootKeys.has(key);
+  }
+
+  private setByPath(target: any, path: string[], value: any) {
+    if (!target || !path.length) return;
+    const rootKey = path[0];
+    if (this.isBlockedRootKey(rootKey)) return;
+
+    if (typeof target.set === 'function') {
+      if (path.length === 1) {
+        target.set({ [rootKey]: value }, this.internalSetOptions);
+      } else {
+        const leafKey = path[path.length - 1];
+        const baseKeys = path.slice(0, -1);
+        const baseKeyPath = baseKeys.join('.');
+        let subtree = target.get(baseKeyPath) ?? target.get(baseKeys[0]) ?? {};
+        const clone = Array.isArray(subtree) ? [...subtree] : { ...subtree };
+        let ref = clone as any;
+        for (let i = 0; i < baseKeys.length - 1; i++) {
+          const k = baseKeys[i + 1];
+          const next = ref[k];
+          if (next && typeof next === 'object') {
+            ref[k] = Array.isArray(next) ? [...next] : { ...next };
+          } else if (typeof next === 'undefined') {
+            ref[k] = {};
+          }
+          ref = ref[k];
+        }
+        ref[leafKey] = value;
+        if (baseKeys.length > 1) {
+          target.set(baseKeyPath, clone, this.internalSetOptions);
+        } else {
+          target.set(baseKeys[0], clone, this.internalSetOptions);
+        }
+      }
+      return;
+    }
+
+    let ref = target as any;
+    for (let i = 0; i < path.length - 1; i++) {
+      const key = path[i];
+      if (ref[key] == null || typeof ref[key] !== 'object') {
+        ref[key] = {};
+      }
+      ref = ref[key];
+    }
+    ref[path[path.length - 1]] = value;
+  }
+
+  private deleteByPath(target: any, path: string[]) {
+    if (!target || !path.length) return;
+    const rootKey = path[0];
+    if (this.isBlockedRootKey(rootKey)) return;
+
+    if (typeof target.unset === 'function' && path.length === 1) {
+      target.unset(rootKey, this.internalSetOptions);
+      return;
+    }
+    let ref = target as any;
+    for (let i = 0; i < path.length - 1; i++) {
+      const key = path[i];
+      if (!ref[key] || typeof ref[key] !== 'object') return;
+      ref = ref[key];
+    }
+    delete ref[path[path.length - 1]];
+  }
+
+  private handleMove(_target: any, _seg: string[], _p: JsonPatch) {}
+
+  destroy(): void {
+    this.em?.off('change:readyLoad', this.handleReadyLoad);
+    this.em?.off(EditorEvents.projectLoad, this.handleProjectLoad);
+    this.em?.off(ComponentsEvents.add, this.handleComponentAdd);
+    this.em?.off(ComponentsEvents.remove, this.handleComponentRemove);
+    this.resetHistory();
+    this.isApplyingExternal = false;
+    super.__destroy?.();
+  }
+
+  private shouldSkipOptions(opts: Record<string, any> = {}) {
+    return opts._skipPatches || opts.avoidStore || opts.noUndo || opts.partial || opts.temporary || opts.fromUndo;
+  }
+
+  private logWithEditor(eventName: string, patch: PatchProps) {
+    try {
+      this.em.log(`[Patches] ${eventName}`, {
+        ns: 'patches',
+        level: 'debug',
+        patch,
+      });
+    } catch {}
+  }
+}

--- a/packages/core/src/patch_manager/index.ts
+++ b/packages/core/src/patch_manager/index.ts
@@ -128,7 +128,10 @@ export default class PatchManager extends ItemManagerModule {
     const collection = (component.collection || parent?.components()) as Components | undefined;
     if (!parent || !collection) return;
     const at = typeof opts.at === 'number' ? opts.at : collection.indexOf(component);
-    const path = this.buildPath('component', parent.getId(), ['components', this.getComponentKey(collection, component, at)]);
+    const path = this.buildPath('component', parent.getId(), [
+      'components',
+      this.getComponentKey(collection, component, at),
+    ]);
     const value = this.cloneValue(component.toJSON());
     const patch: JsonPatch = { op: 'add', path, value };
     const inverse: JsonPatch = { op: 'remove', path };

--- a/packages/core/src/patch_manager/index.ts
+++ b/packages/core/src/patch_manager/index.ts
@@ -8,9 +8,18 @@ import { Collection } from '../common';
 import EditorModel from '../editor/model/Editor';
 import { EditorEvents } from '../editor/types';
 import { createId } from '../utils/mixins';
-import type { JsonPatch, PatchManagerConfig, PatchProps } from './types';
+import { enablePatches, produceWithPatches } from 'immer';
+import type {
+  JsonPatch,
+  PatchAdapter,
+  PatchAdapterChange,
+  PatchAdapterEvent,
+  PatchManagerConfig,
+  PatchProps,
+} from './types';
 
 const encodePointer = (segment: string) => segment.replace(/~/g, '~0').replace(/\//g, '~1');
+enablePatches();
 
 export default class PatchManager extends ItemManagerModule {
   storageKey = '';
@@ -26,6 +35,10 @@ export default class PatchManager extends ItemManagerModule {
   private coalesceMs = 0;
   private maxHistory = 500;
   private isApplyingExternal = false;
+  private adapters = new Map<string, PatchAdapter<any>>();
+  private adapterListeners: { adapter: string; target: any; event: string; handler: (...args: any[]) => void }[] = [];
+  private trackingBound = false;
+  private fractionalGen?: (a: string | null, b: string | null) => string;
 
   private internalSetOptions = {
     fromUndo: true,
@@ -44,6 +57,7 @@ export default class PatchManager extends ItemManagerModule {
     const cfg = (this.getConfig() as any) ?? {};
     const normalized = typeof cfg === 'boolean' ? { enable: cfg } : cfg;
     this.init({ enable: true, ...normalized });
+    this.registerDefaultAdapters();
     this.setupTracking();
   }
 
@@ -55,22 +69,99 @@ export default class PatchManager extends ItemManagerModule {
     return this;
   }
 
+  private registerDefaultAdapters() {
+    this.registerAdapter(this.createComponentAdapter());
+    this.registerAdapter(this.createCssRuleAdapter());
+  }
+
+  registerAdapter<T>(adapter: PatchAdapter<T>) {
+    const normalized = this.normalizeAdapter(adapter);
+    this.unbindAdapter(normalized.type);
+    this.adapters.set(normalized.type, normalized);
+
+    if (this.trackingBound) {
+      this.bindAdapter(normalized);
+    }
+
+    return this;
+  }
+
+  private normalizeAdapter<T>(adapter: PatchAdapter<T>): PatchAdapter<T> {
+    if (adapter.blockedKeys && !(adapter.blockedKeys instanceof Set)) {
+      adapter.blockedKeys = new Set(adapter.blockedKeys);
+    }
+    return adapter;
+  }
+
+  private bindAdapters() {
+    if (this.trackingBound) return;
+    this.trackingBound = true;
+    this.adapters.forEach((adapter) => this.bindAdapter(adapter));
+  }
+
+  private bindAdapter(adapter: PatchAdapter<any>) {
+    adapter.events?.forEach((event) => this.bindAdapterEvent(adapter, event));
+    if (this.isReady) {
+      adapter.onReady?.(this);
+    }
+  }
+
+  private bindAdapterEvent(adapter: PatchAdapter<any>, event: PatchAdapterEvent) {
+    const target = event.target ? event.target(this) : this.em;
+    if (!target?.on) return;
+    const listener = (...args: any[]) => {
+      const options = event.getOptions?.(...args) ?? this.extractOptions(args);
+      const skipTracking = !event.skipTrackingCheck && (!this.canTrack() || this.shouldSkipOptions(options));
+      if (skipTracking) return;
+      const result = event.handler({ args, options });
+      if (result?.patches?.length) {
+        this.collect(result.patches, result.inverse || []);
+      }
+    };
+
+    target.on(event.event, listener);
+    this.adapterListeners.push({ adapter: adapter.type, target, event: event.event, handler: listener });
+  }
+
+  private extractOptions(args: any[]) {
+    const last = args[args.length - 1];
+    const beforeLast = args[args.length - 2];
+    if (last && typeof last === 'object') return last;
+    if (beforeLast && typeof beforeLast === 'object') return beforeLast;
+  }
+
+  private unbindAdapter(type: string) {
+    const listeners = this.adapterListeners.filter((item) => item.adapter === type);
+    listeners.forEach(({ target, event, handler }) => target?.off?.(event, handler));
+    this.adapterListeners = this.adapterListeners.filter((item) => item.adapter !== type);
+  }
+
+  private unbindAllAdapters() {
+    this.adapterListeners.forEach(({ target, event, handler }) => target?.off?.(event, handler));
+    this.adapterListeners = [];
+    this.trackingBound = false;
+  }
+
+  private notifyAdaptersReady() {
+    if (!this.isReady) return;
+    this.adapters.forEach((adapter) => adapter.onReady?.(this));
+  }
+
   private setupTracking() {
     const { em } = this;
-    this.cssRules = em.Css?.getAll?.();
-    this.ensureAllCssRuleIds();
-    this.cssRules?.on('add', this.handleCssRuleAdd);
     this.isReady = !!em.get('readyLoad');
+    this.ensureAllCssRuleIds();
+    this.bindAdapters();
+    this.notifyAdaptersReady();
     em.on('change:readyLoad', this.handleReadyLoad);
     em.on(EditorEvents.projectLoad, this.handleProjectLoad);
-    em.on(ComponentsEvents.add, this.handleComponentAdd);
-    em.on(ComponentsEvents.remove, this.handleComponentRemove);
   }
 
   private handleReadyLoad = () => {
     if (!this.em.get('readyLoad')) return;
     this.isReady = true;
     this.ensureAllCssRuleIds();
+    this.notifyAdaptersReady();
     this.resetHistory();
     this.em.off('change:readyLoad', this.handleReadyLoad);
   };
@@ -78,60 +169,62 @@ export default class PatchManager extends ItemManagerModule {
   private handleProjectLoad = () => {
     this.resetHistory();
     this.ensureAllCssRuleIds();
+    this.notifyAdaptersReady();
   };
 
   handleChange(data: Record<string, any> = {}, opts: Record<string, any> = {}) {
     if (!this.canTrack() || this.shouldSkipOptions(opts)) return;
     const patches: JsonPatch[] = [];
     const reverse: JsonPatch[] = [];
-    const component = data.component as Component | undefined;
-    const changed = data.changed as Record<string, any> | undefined;
-    const rule = data.rule as CssRule | undefined;
 
-    if (component && changed) {
-      this.handleComponentChange(component, changed, patches, reverse);
-    } else if (rule && changed) {
-      this.handleRuleChange(rule, changed, patches, reverse);
-    }
+    this.adapters.forEach((adapter) => {
+      const change = this.getChangeFromData(adapter, data);
+      change && this.handleAdapterChange(adapter, change, patches, reverse);
+    });
 
-    if (patches.length) {
-      this.collect(patches, reverse);
-    }
+    patches.length && this.collect(patches, reverse);
   }
 
-  private handleComponentChange(
-    component: Component,
-    changed: Record<string, any>,
+  private getChangeFromData<T>(adapter: PatchAdapter<T>, data: Record<string, any>): PatchAdapterChange<T> | null {
+    if (adapter.getChange) {
+      return adapter.getChange(data);
+    }
+    const { sourceKeys = [] } = adapter;
+    const changed = data.changed as Record<string, any> | undefined;
+    if (!changed) return null;
+
+    for (const key of sourceKeys) {
+      const target = data[key] as T | undefined;
+      if (target) {
+        return { target, changed };
+      }
+    }
+
+    return null;
+  }
+
+  private handleAdapterChange<T>(
+    adapter: PatchAdapter<T>,
+    change: PatchAdapterChange<T>,
     patches: JsonPatch[],
     reverse: JsonPatch[],
   ) {
-    const compId = component.getId();
-    Object.keys(changed).forEach((key) => {
-      if (this.isBlockedRootKey(key)) return;
-      const path = this.buildPath('component', compId, [key]);
-      const nextVal = changed[key];
-      const prevVal = component.previous ? component.previous(key) : undefined;
-      const { patch, inverse } = this.buildPatchPair(path, prevVal, nextVal);
-      patch && patches.push(patch);
-      inverse && reverse.push(inverse);
-    });
-  }
-
-  private handleRuleChange(rule: CssRule, changed: Record<string, any>, patches: JsonPatch[], reverse: JsonPatch[]) {
-    const ruleId = this.ensureCssRuleId(rule);
+    const { target, changed } = change;
+    const id = adapter.getId(target);
+    if (!id) return;
 
     Object.keys(changed).forEach((key) => {
-      const path = this.buildPath('cssRule', `${ruleId}`, [key]);
-      const nextVal = changed[key];
-      const prevVal = rule.previous ? rule.previous(key) : undefined;
-      const { patch, inverse } = this.buildPatchPair(path, prevVal, nextVal);
-      patch && patches.push(patch);
-      inverse && reverse.push(inverse);
+      const filter = adapter.filterChangedKey;
+      if (filter ? !filter(key) : this.isBlockedKey(key, adapter)) return;
+      const nextVal = this.cloneValue(changed[key]);
+      const prevVal = (target as any)?.previous ? (target as any).previous(key) : undefined;
+      const pair = this.buildImmerPatchPair(adapter, `${id}`, key, prevVal, nextVal);
+      patches.push(...pair.patches);
+      reverse.push(...pair.inverse);
     });
   }
 
   private handleComponentAdd = (component: Component, opts: any = {}) => {
-    if (!this.canTrack() || this.shouldSkipOptions(opts)) return;
     const parent = component.parent();
     const collection = (component.collection || parent?.components()) as Components | undefined;
     if (!parent || !collection) return;
@@ -143,11 +236,10 @@ export default class PatchManager extends ItemManagerModule {
     const value = this.cloneValue(component.toJSON());
     const patch: JsonPatch = { op: 'add', path, value };
     const inverse: JsonPatch = { op: 'remove', path };
-    this.collect([patch], [inverse]);
+    return { patches: [patch], inverse: [inverse] };
   };
 
   private handleComponentRemove = (component: Component, opts: any = {}) => {
-    if (!this.canTrack() || this.shouldSkipOptions(opts)) return;
     const collection = (opts.collection || component.prevColl) as Components | undefined;
     const parent = component.parent({ prev: true });
     if (!parent || !collection) return;
@@ -159,8 +251,63 @@ export default class PatchManager extends ItemManagerModule {
     const reverseVal = this.cloneValue(component.toJSON());
     const patch: JsonPatch = { op: 'remove', path };
     const inverse: JsonPatch = { op: 'add', path, value: reverseVal };
-    this.collect([patch], [inverse]);
+    return { patches: [patch], inverse: [inverse] };
   };
+
+  private createComponentAdapter(): PatchAdapter<Component> {
+    return {
+      type: 'component',
+      sourceKeys: ['component'],
+      blockedKeys: PatchManager.blockedRootKeys,
+      getId: (component) => component.getId(),
+      resolve: (em, id) => em.Components?.getById(id),
+      events: [
+        {
+          event: ComponentsEvents.add,
+          getOptions: (...args: any[]) => args[1],
+          handler: ({ args }) => this.handleComponentAdd(args[0] as Component, args[1]),
+        },
+        {
+          event: ComponentsEvents.remove,
+          getOptions: (...args: any[]) => args[1],
+          handler: ({ args }) => this.handleComponentRemove(args[0] as Component, args[1]),
+        },
+      ],
+      applyPatch: (target, path, patch) => {
+        if (path[0] === 'components') {
+          return this.applyComponentsPatch(target, path.slice(1), patch);
+        }
+        return false;
+      },
+    };
+  }
+
+  private createCssRuleAdapter(): PatchAdapter<CssRule> {
+    return {
+      type: 'cssRule',
+      sourceKeys: ['rule'],
+      getChange: (data) => {
+        const rule = data.rule as CssRule | undefined;
+        const changed = data.changed as Record<string, any> | undefined;
+        if (!rule || !changed) return null;
+        this.ensureCssRuleId(rule);
+        return { target: rule, changed };
+      },
+      getId: (rule) => this.ensureCssRuleId(rule),
+      resolve: (em, id) => em.Css?.rules?.get(id) ?? em.Css?.get(id),
+      events: [
+        {
+          event: 'add',
+          target: () => this.getCssRules(),
+          handler: ({ args }) => {
+            this.ensureCssRuleId(args[0] as CssRule);
+          },
+          skipTrackingCheck: true,
+        },
+      ],
+      onReady: () => this.ensureAllCssRuleIds(),
+    };
+  }
 
   private cloneValue(value: any) {
     if (typeof value === 'undefined') return value;
@@ -171,22 +318,29 @@ export default class PatchManager extends ItemManagerModule {
     }
   }
 
-  private buildPatchPair(path: string, prevVal: any, nextVal: any) {
-    const op = this.getOp(prevVal, nextVal);
-    const invOp = this.getOp(nextVal, prevVal);
-    const patch = op ? this.buildPatch(op, path, nextVal) : null;
-    const inverse = invOp ? this.buildPatch(invOp, path, prevVal) : null;
-    return { patch, inverse };
+  private buildImmerPatchPair(adapter: PatchAdapter<any>, id: string, key: string, prevVal: any, nextVal: any) {
+    const base = { value: this.cloneValue(prevVal) };
+    const [, forward, backward] = produceWithPatches(base, (draft) => {
+      (draft as any).value = this.cloneValue(nextVal);
+    });
+
+    return {
+      patches: this.toJsonPatches(adapter, id, key, forward),
+      inverse: this.toJsonPatches(adapter, id, key, backward),
+    };
   }
 
-  private buildPatch(op: JsonPatch['op'], path: string, value: any): JsonPatch {
-    const cloned = this.cloneValue(value);
-    return op === 'remove' ? { op, path } : { op, path, value: cloned };
-  }
-
-  private getOp(prevVal: any, nextVal: any): JsonPatch['op'] | null {
-    if (typeof nextVal === 'undefined') return 'remove';
-    return typeof prevVal === 'undefined' ? 'add' : 'replace';
+  private toJsonPatches(adapter: PatchAdapter<any>, id: string, key: string, list: any[] = []) {
+    return list
+      .map((patch) => {
+        const pathArr: (string | number)[] = Array.isArray(patch.path) ? patch.path : [];
+        const [, ...rest] = pathArr; // drop synthetic "value" root
+        const fullPath = this.buildPath(adapter.type, `${id}`, [key, ...rest]);
+        if (!fullPath) return null;
+        const value = typeof patch.value === 'undefined' ? undefined : this.cloneValue(patch.value);
+        return patch.op === 'remove' ? { op: patch.op, path: fullPath } : { op: patch.op, path: fullPath, value };
+      })
+      .filter(Boolean) as JsonPatch[];
   }
 
   private buildPath(type: string, id: string, segments: (string | number)[] = []) {
@@ -195,15 +349,76 @@ export default class PatchManager extends ItemManagerModule {
   }
 
   private getComponentKey(coll?: Components, cmp?: Component, at?: number) {
+    if (!coll) return '0';
     const getFractional = (coll as any)?.getFractionalKey;
+    const supportsFractional = this.supportsFractionalIndexing(coll);
+
+    if (supportsFractional) {
+      const key = this.buildFractionalKey(coll, typeof at === 'number' ? at : cmp ? coll.indexOf(cmp) : undefined);
+      if (key) return key;
+    }
+
     if (typeof getFractional === 'function' && cmp) {
       return getFractional.call(coll, cmp);
     }
+
     if (typeof at === 'number') {
       return `${at}`;
     }
-    const idx = coll && cmp ? coll.indexOf(cmp) : -1;
+    const idx = cmp ? coll.indexOf(cmp) : -1;
     return `${idx >= 0 ? idx : 0}`;
+  }
+
+  private supportsFractionalIndexing(coll: any) {
+    return (
+      typeof coll?.findByFractionalKey === 'function' ||
+      typeof coll?.setFractionalKey === 'function' ||
+      typeof coll?.getIndexFromFractionalKey === 'function'
+    );
+  }
+
+  private buildFractionalKey(coll: any, at?: number) {
+    const gen = this.getGenerateKeyBetween();
+    if (!gen) return '';
+    const index = typeof at === 'number' ? at : coll?.length || 0;
+    const prev = index > 0 ? coll.at(index - 1) : null;
+    const next = index < coll.length ? coll.at(index) : null;
+    const prevKey = this.getExistingFractionalKey(coll, prev);
+    const nextKey = this.getExistingFractionalKey(coll, next);
+    return gen(prevKey || null, nextKey || null) || '';
+  }
+
+  private getExistingFractionalKey(coll: any, model: any) {
+    if (!model) return null;
+    const getter = coll?.getFractionalKey;
+    const key =
+      (typeof getter === 'function' && getter.call(coll, model)) ||
+      (model as any)?.fractionalKey ||
+      (typeof model?.get === 'function' ? model.get('fractionalKey') : undefined);
+    return key || null;
+  }
+
+  private setFractionalKey(coll: any, model: any, key: string) {
+    if (!key || !model) return;
+    if (typeof coll?.setFractionalKey === 'function') {
+      coll.setFractionalKey(model, key);
+    } else {
+      (model as any).fractionalKey = key;
+      typeof model?.set === 'function' && model.set('fractionalKey', key, this.internalSetOptions);
+    }
+  }
+
+  // Lazy-load fractional-indexing to work in CJS/Jest environments without extra transpilation.
+  private getGenerateKeyBetween() {
+    if (this.fractionalGen) return this.fractionalGen;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('fractional-indexing');
+      this.fractionalGen = mod?.generateKeyBetween || mod?.default?.generateKeyBetween || mod?.default;
+    } catch (err) {
+      this.fractionalGen = undefined;
+    }
+    return this.fractionalGen;
   }
 
   private resetHistory() {
@@ -344,7 +559,8 @@ export default class PatchManager extends ItemManagerModule {
   private applyJsonPatch(p: JsonPatch) {
     const seg = p.path.split('/').filter(Boolean);
     const [objectType, objectId, ...rest] = seg;
-    const target = this.resolveTarget(objectType, objectId);
+    const adapter = objectType ? this.adapters.get(objectType) : null;
+    const target = objectType && objectId && adapter ? adapter.resolve(this.em, objectId) : null;
 
     if (this.debug) {
       console.log('[PatchManager] applyJsonPatch', {
@@ -352,24 +568,24 @@ export default class PatchManager extends ItemManagerModule {
         objectType,
         objectId,
         rest,
+        adapter: adapter?.type,
         resolved: !!target,
       });
     }
 
-    if (!objectType || !objectId) return;
-    if (!target) return;
+    if (!objectType || !objectId || !adapter || !target) return;
 
-    if (rest[0] === 'components' && this.applyComponentsPatch(target, rest.slice(1), p)) {
+    if (adapter.applyPatch && adapter.applyPatch(target, rest, p)) {
       return;
     }
 
     switch (p.op) {
       case 'add':
       case 'replace':
-        this.setByPath(target, rest, p.value);
+        this.setByPath(target, rest, p.value, adapter);
         break;
       case 'remove':
-        this.deleteByPath(target, rest);
+        this.deleteByPath(target, rest, adapter);
         break;
       case 'move':
         this.handleMove(target, seg, p);
@@ -398,7 +614,7 @@ export default class PatchManager extends ItemManagerModule {
         if (patch.value) {
           const added = coll.add(patch.value as any, opts);
           const list = Array.isArray(added) ? added : [added];
-          list.forEach((m) => coll.setFractionalKey?.(m, key));
+          list.forEach((m) => this.setFractionalKey(coll, m, key));
         }
         return true;
       }
@@ -416,8 +632,11 @@ export default class PatchManager extends ItemManagerModule {
 
   private findComponentByKey(coll: any, key: string) {
     if (!coll) return null;
-    if (typeof coll.findByFractionalKey === 'function') {
+    if (typeof coll.findByFractionalKey === 'function' && isNaN(Number(key))) {
       return coll.findByFractionalKey(key);
+    }
+    if (isNaN(Number(key))) {
+      return coll.find((m: any) => this.getExistingFractionalKey(coll, m) === key) || null;
     }
     const idx = Number(key);
     return Number.isNaN(idx) ? null : coll.at(idx);
@@ -428,7 +647,9 @@ export default class PatchManager extends ItemManagerModule {
       return coll.getIndexFromFractionalKey(key);
     }
     const idx = Number(key);
-    return Number.isNaN(idx) ? coll.length : idx;
+    if (!Number.isNaN(idx)) return idx;
+    const model = this.findComponentByKey(coll, key);
+    return model ? coll.indexOf(model) : coll.length;
   }
 
   private applyComponentsMove(coll: any, key: string, patch: JsonPatch) {
@@ -449,20 +670,13 @@ export default class PatchManager extends ItemManagerModule {
     const at = this.resolveComponentIndex(coll, key);
     const added = coll.add(model, { ...this.internalSetOptions, at });
     const list = Array.isArray(added) ? added : [added];
-    list.forEach((m) => coll.setFractionalKey?.(m, key));
+    list.forEach((m) => this.setFractionalKey(coll, m, key));
     return true;
   }
 
   private resolveTarget(type: string, id: string): any {
-    const { em } = this;
-    switch (type) {
-      case 'component':
-        return em.Components?.getById(id);
-      case 'cssRule':
-        return em.Css?.rules?.get(id) ?? em.Css?.get(id);
-      default:
-        return null;
-    }
+    const adapter = this.adapters.get(type);
+    return adapter ? adapter.resolve(this.em, id) : null;
   }
 
   private ensureCssRuleId(rule?: CssRule) {
@@ -485,27 +699,27 @@ export default class PatchManager extends ItemManagerModule {
     return ruleId;
   }
 
-  private handleCssRuleAdd = (rule: CssRule) => {
-    this.ensureCssRuleId(rule);
-  };
-
-  private ensureAllCssRuleIds() {
+  private getCssRules() {
     if (!this.cssRules) {
       this.cssRules = this.em.Css?.getAll?.();
-      this.cssRules?.on('add', this.handleCssRuleAdd);
     }
-    this.cssRules?.each((rule: CssRule) => this.ensureCssRuleId(rule));
+    return this.cssRules;
   }
 
-  private isBlockedRootKey(key?: string) {
+  private ensureAllCssRuleIds() {
+    this.getCssRules()?.each((rule: CssRule) => this.ensureCssRuleId(rule));
+  }
+
+  private isBlockedKey(key?: string, adapter?: PatchAdapter<any>) {
     if (!key) return false;
-    return PatchManager.blockedRootKeys.has(key);
+    const blocked = adapter?.blockedKeys as Set<string> | undefined;
+    return !!blocked?.has(key);
   }
 
-  private setByPath(target: any, path: string[], value: any) {
+  private setByPath(target: any, path: string[], value: any, adapter?: PatchAdapter<any>) {
     if (!target || !path.length) return;
     const rootKey = path[0];
-    if (this.isBlockedRootKey(rootKey)) return;
+    if (this.isBlockedKey(rootKey, adapter)) return;
 
     if (typeof target.set === 'function') {
       if (path.length === 1) {
@@ -548,10 +762,10 @@ export default class PatchManager extends ItemManagerModule {
     ref[path[path.length - 1]] = value;
   }
 
-  private deleteByPath(target: any, path: string[]) {
+  private deleteByPath(target: any, path: string[], adapter?: PatchAdapter<any>) {
     if (!target || !path.length) return;
     const rootKey = path[0];
-    if (this.isBlockedRootKey(rootKey)) return;
+    if (this.isBlockedKey(rootKey, adapter)) return;
 
     if (typeof target.unset === 'function' && path.length === 1) {
       target.unset(rootKey, this.internalSetOptions);
@@ -569,11 +783,9 @@ export default class PatchManager extends ItemManagerModule {
   private handleMove(_target: any, _seg: string[], _p: JsonPatch) {}
 
   destroy(): void {
-    this.cssRules?.off('add', this.handleCssRuleAdd);
+    this.unbindAllAdapters();
     this.em?.off('change:readyLoad', this.handleReadyLoad);
     this.em?.off(EditorEvents.projectLoad, this.handleProjectLoad);
-    this.em?.off(ComponentsEvents.add, this.handleComponentAdd);
-    this.em?.off(ComponentsEvents.remove, this.handleComponentRemove);
     this.resetHistory();
     this.isApplyingExternal = false;
     super.__destroy?.();

--- a/packages/core/src/patch_manager/types.ts
+++ b/packages/core/src/patch_manager/types.ts
@@ -21,3 +21,39 @@ export interface PatchManagerConfig {
   coalesceMs?: number;
   debug?: boolean;
 }
+
+export interface PatchAdapterChange<T = any> {
+  target: T;
+  changed: Record<string, any>;
+}
+
+export interface PatchAdapterEventContext {
+  args: any[];
+  options?: Record<string, any>;
+}
+
+export interface PatchAdapterEventResult {
+  patches?: JsonPatch[];
+  inverse?: JsonPatch[];
+}
+
+export interface PatchAdapterEvent {
+  event: string;
+  handler: (context: PatchAdapterEventContext) => PatchAdapterEventResult | void;
+  getOptions?: (...args: any[]) => Record<string, any> | undefined;
+  skipTrackingCheck?: boolean;
+  target?: (manager: any) => any;
+}
+
+export interface PatchAdapter<T = any> {
+  type: string;
+  sourceKeys?: string[];
+  getChange?: (data: Record<string, any>) => PatchAdapterChange<T> | null;
+  getId: (target: T) => string | undefined;
+  resolve: (em: any, id: string) => T | undefined | null;
+  filterChangedKey?: (key: string) => boolean;
+  events?: PatchAdapterEvent[];
+  applyPatch?: (target: T, path: string[], patch: JsonPatch) => boolean | void;
+  onReady?: (manager: any) => void;
+  blockedKeys?: Set<string> | string[];
+}

--- a/packages/core/src/patch_manager/types.ts
+++ b/packages/core/src/patch_manager/types.ts
@@ -1,0 +1,23 @@
+export type JsonPatchOp = 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test';
+
+export interface JsonPatch {
+  op: JsonPatchOp;
+  path: string;
+  from?: string;
+  value?: any;
+}
+
+export interface PatchProps {
+  id: string;
+  ts: number;
+  changes: JsonPatch[];
+  reverseChanges: JsonPatch[];
+  meta?: Record<string, any>;
+}
+
+export interface PatchManagerConfig {
+  enable?: boolean;
+  maxHistory?: number;
+  coalesceMs?: number;
+  debug?: boolean;
+}

--- a/packages/core/test/specs/patch_manager/index.ts
+++ b/packages/core/test/specs/patch_manager/index.ts
@@ -95,8 +95,8 @@ describe('Patch Manager', () => {
 
     rule.setStyle({ color: 'blue' });
 
-    expect(updates).toHaveLength(1);
-    const [patch] = updates;
+    expect(updates.length).toBeGreaterThanOrEqual(1);
+    const patch = updates[updates.length - 1];
     const ruleId = (rule as any).id || rule.get('id');
     expect(ruleId).toBeTruthy();
     expect(patch.changes[0]).toMatchObject({

--- a/packages/core/test/specs/patch_manager/index.ts
+++ b/packages/core/test/specs/patch_manager/index.ts
@@ -1,8 +1,9 @@
 import Editor from '../../../src/editor';
 import PatchManager from '../../../src/patch_manager';
-import { PatchProps } from '../../../src/patch_manager/types';
+import { PatchAdapter, PatchProps } from '../../../src/patch_manager/types';
 import Component from '../../../src/dom_components/model/Component';
 import EditorModel from '../../../src/editor/model/Editor';
+import { Model } from '../../../src/common';
 import { setupTestEditor } from '../../common';
 
 describe('Patch Manager', () => {
@@ -83,5 +84,68 @@ describe('Patch Manager', () => {
     expect(updates).toHaveLength(0);
     expect(wrapper.components()).toHaveLength(1);
     expect(wrapper.components().at(0).get('content')).toBe('from patch');
+  });
+
+  test('collects css rule changes with adapter', () => {
+    const updates: PatchProps[] = [];
+    editor.on('patch:update', ({ patch }) => updates.push(patch));
+
+    const rule = editor.Css.addRules('.test { color: red; }')[0];
+    updates.length = 0;
+
+    rule.setStyle({ color: 'blue' });
+
+    expect(updates).toHaveLength(1);
+    const [patch] = updates;
+    const ruleId = (rule as any).id || rule.get('id');
+    expect(ruleId).toBeTruthy();
+    expect(patch.changes[0]).toMatchObject({
+      op: 'replace',
+      path: `/cssRule/${ruleId}/style`,
+    });
+    expect((patch.changes[0] as any).value?.color).toBe('blue');
+    expect(patch.reverseChanges[0]).toMatchObject({
+      op: 'replace',
+      path: `/cssRule/${ruleId}/style`,
+    });
+    expect((patch.reverseChanges[0] as any).value?.color).toBe('red');
+
+    patches.undo();
+    expect(rule.getStyle().color).toBe('red');
+
+    patches.redo();
+    expect(rule.getStyle().color).toBe('blue');
+  });
+
+  test('allows registering custom adapters without touching core', () => {
+    const updates: PatchProps[] = [];
+    editor.on('patch:update', ({ patch }) => updates.push(patch));
+
+    const custom = new Model({ id: 'custom-1', value: 'one' });
+    const adapter: PatchAdapter<Model> = {
+      type: 'custom',
+      sourceKeys: ['custom'],
+      getId: (model) => model.get('id') as string,
+      resolve: (_em: EditorModel, id: string) => (id === custom.get('id') ? custom : null),
+    };
+
+    patches.registerAdapter(adapter);
+
+    custom.set('value', 'two');
+    const changed = custom.changedAttributes() || {};
+    em.changesUp({}, { custom, changed });
+
+    expect(updates).toHaveLength(1);
+    const changePatch = updates[0];
+    expect(changePatch.changes[0]).toMatchObject({
+      op: 'replace',
+      path: `/custom/${custom.get('id')}/value`,
+      value: 'two',
+    });
+    expect(changePatch.reverseChanges[0]).toMatchObject({
+      op: 'replace',
+      path: `/custom/${custom.get('id')}/value`,
+      value: 'one',
+    });
   });
 });

--- a/packages/core/test/specs/patch_manager/index.ts
+++ b/packages/core/test/specs/patch_manager/index.ts
@@ -1,0 +1,87 @@
+import Editor from '../../../src/editor';
+import PatchManager from '../../../src/patch_manager';
+import { PatchProps } from '../../../src/patch_manager/types';
+import Component from '../../../src/dom_components/model/Component';
+import EditorModel from '../../../src/editor/model/Editor';
+import { setupTestEditor } from '../../common';
+
+describe('Patch Manager', () => {
+  let editor: Editor;
+  let em: EditorModel;
+  let patches: PatchManager;
+  let wrapper: Component;
+
+  beforeEach(() => {
+    ({ editor, em } = setupTestEditor({ withCanvas: true }));
+    em.initModules();
+    patches = editor.Patches;
+    wrapper = em.getWrapper()!;
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  test('collects component changes and supports undo/redo', () => {
+    const updates: PatchProps[] = [];
+    editor.on('patch:update', ({ patch }) => updates.push(patch));
+
+    const cmp = wrapper.append({ tagName: 'div', content: 'first' })[0];
+
+    expect(patches.canTrack()).toBe(true);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].changes[0]).toMatchObject({
+      op: 'add',
+      path: `/component/${wrapper.getId()}/components/0`,
+    });
+
+    cmp.set('content', 'second');
+    expect(updates).toHaveLength(2);
+
+    const changePatch = updates[1];
+    expect(changePatch.changes[0]).toMatchObject({
+      op: 'replace',
+      path: `/component/${cmp.getId()}/content`,
+      value: 'second',
+    });
+    expect(changePatch.reverseChanges[0]).toMatchObject({
+      op: 'replace',
+      path: `/component/${cmp.getId()}/content`,
+      value: 'first',
+    });
+
+    patches.undo();
+    expect(cmp.get('content')).toBe('first');
+
+    patches.redo();
+    expect(cmp.get('content')).toBe('second');
+  });
+
+  test('applies external component patches without re-tracking', () => {
+    const updates: PatchProps[] = [];
+    const applied: PatchProps[] = [];
+    editor.on('patch:update', ({ patch }) => updates.push(patch));
+    editor.on('patch:applied:external', ({ patch }) => applied.push(patch));
+
+    const wrapperId = wrapper.getId();
+    const externalPatch: PatchProps = {
+      id: 'ext',
+      ts: Date.now(),
+      changes: [
+        {
+          op: 'add',
+          path: `/component/${wrapperId}/components/0`,
+          value: { type: 'default', tagName: 'div', content: 'from patch' },
+        },
+      ],
+      reverseChanges: [],
+    };
+
+    patches.apply(externalPatch);
+
+    expect(applied).toContain(externalPatch);
+    expect(updates).toHaveLength(0);
+    expect(wrapper.components()).toHaveLength(1);
+    expect(wrapper.components().at(0).get('content')).toBe('from patch');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,9 +235,15 @@ importers:
       codemirror-formatting:
         specifier: 1.0.0
         version: 1.0.0
+      fractional-indexing:
+        specifier: ^3.2.0
+        version: 3.2.0
       html-entities:
         specifier: ~1.4.0
         version: 1.4.0
+      immer:
+        specifier: ^10.2.0
+        version: 10.2.0
       promise-polyfill:
         specifier: 8.3.0
         version: 8.3.0
@@ -4183,6 +4189,10 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  fractional-indexing@3.2.0:
+    resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
   fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
     engines: {node: '>=0.10.0'}
@@ -4730,6 +4740,9 @@ packages:
 
   immediate@3.3.0:
     resolution: {integrity: sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
   immutable@4.3.7:
     resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
@@ -13766,6 +13779,8 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  fractional-indexing@3.2.0: {}
+
   fragment-cache@0.2.1:
     dependencies:
       map-cache: 0.2.2
@@ -14437,6 +14452,8 @@ snapshots:
   ignore@5.3.2: {}
 
   immediate@3.3.0: {}
+
+  immer@10.2.0: {}
 
   immutable@4.3.7: {}
 


### PR DESCRIPTION
made the PatchManager type-agnostic based on immersive (enablePatches + ProduceWithPatches) and added fractional indexing for key components (via lazy fractional indexing). The JsonPatch format and events/apply are preserved, so CollaborativeManager works as before. Updated/added tests for the new pipeline.