### PR TITLE
allow for more complex selectors in parseSelector

### DIFF
--- a/packages/core/src/parser/model/BrowserParserCss.ts
+++ b/packages/core/src/parser/model/BrowserParserCss.ts
@@ -72,11 +72,9 @@ export const parseSelector = (str = '') => {
   // Can also accept SINGLE ID selectors, eg. `#myid`, `#myid:hover`
   // Composed are not valid: `#myid.some-class`, `#myid.some-class:hover
 
-  const checkForClass =
-    /^(\.[\w\-]+)+((:{1,2}[\w\-]+)(\([^)]*\))?)*$/;
+  const checkForClass = /^(\.[\w\-]+)+((:{1,2}[\w\-]+)(\([^)]*\))?)*$/;
 
-  const checkForId =
-    /^#[\w\-]+((:{1,2}[\w\-]+)(\([^)]*\))?)*$/;
+  const checkForId = /^#[\w\-]+((:{1,2}[\w\-]+)(\([^)]*\))?)*$/;
 
   for (let i = 0; i < sels.length; i++) {
     const sel = sels[i].trim();

--- a/packages/core/src/parser/model/BrowserParserCss.ts
+++ b/packages/core/src/parser/model/BrowserParserCss.ts
@@ -61,7 +61,7 @@ const SINGLE_AT_RULE_NAMES = SINGLE_AT_RULE_TYPES.map((n) => AT_RULE_NAMES[n]);
  * console.log(res);
  * // { result: [['test1'], ['test1', 'test2']], add: ['.test2 .test3'] }
  */
-const parseSelector = (str = '') => {
+export const parseSelector = (str = '') => {
   const add: string[] = [];
   const result: string[][] = [];
   const sels = str.split(',');

--- a/packages/core/src/parser/model/BrowserParserCss.ts
+++ b/packages/core/src/parser/model/BrowserParserCss.ts
@@ -61,30 +61,35 @@ const SINGLE_AT_RULE_NAMES = SINGLE_AT_RULE_TYPES.map((n) => AT_RULE_NAMES[n]);
  * console.log(res);
  * // { result: [['test1'], ['test1', 'test2']], add: ['.test2 .test3'] }
  */
-export const parseSelector = (str = '') => {
+const parseSelector = (str = '') => {
   const add: string[] = [];
   const result: string[][] = [];
   const sels = str.split(',');
 
-  for (var i = 0, len = sels.length; i < len; i++) {
-    var sel = sels[i].trim();
+  // Will accept only concatenated classes and last
+  // class might be with state (eg. :hover) complex state (:hover:not(.active))
+  // as long as the state does not contain commas.
+  // Can also accept SINGLE ID selectors, eg. `#myid`, `#myid:hover`
+  // Composed are not valid: `#myid.some-class`, `#myid.some-class:hover
 
-    // Will accept only concatenated classes and last
-    // class might be with state (eg. :hover), nothing else.
-    // Can also accept SINGLE ID selectors, eg. `#myid`, `#myid:hover`
-    // Composed are not valid: `#myid.some-class`, `#myid.some-class:hover`
-    if (/^(\.{1}[\w\-]+)+(:{1,2}[\w\-()]+)?$/gi.test(sel) || /^(#{1}[\w\-]+){1}(:{1,2}[\w\-()]+)?$/gi.test(sel)) {
-      var cls = sel.split('.').filter(Boolean);
-      result.push(cls);
+  const checkForClass =
+    /^(\.[\w\-]+)+((:{1,2}[\w\-]+)(\([^)]*\))?)*$/;
+
+  const checkForId =
+    /^#[\w\-]+((:{1,2}[\w\-]+)(\([^)]*\))?)*$/;
+
+  for (let i = 0; i < sels.length; i++) {
+    const sel = sels[i].trim();
+
+    if (checkForClass.test(sel) || checkForId.test(sel)) {
+      const parts = sel.split(/\.(?![^()]*\))/).filter(Boolean);
+      result.push(parts);
     } else {
       add.push(sel);
     }
   }
 
-  return {
-    result,
-    add,
-  };
+  return { result, add };
 };
 
 /**

--- a/packages/core/test/specs/parser/model/ParserCss.ts
+++ b/packages/core/test/specs/parser/model/ParserCss.ts
@@ -63,6 +63,12 @@ describe('ParserCss', () => {
       var result = [['test4', 'test5:hover']];
       expect(parseSelector(str).result).toEqual(result);
     });
+
+    test('Parse selectors with complex state', () => {
+      var str = '.test1. test2, .test2>test3, .test4.test5:hover:not(.active.some-class)';
+      var result = [['test4', 'test5:hover:not(.active.some-class)']];
+      expect(parseSelector(str).result).toEqual(result);
+    });
   });
 
   test('Parse simple rule', () => {


### PR DESCRIPTION
this allowes you to have a selector with additional pseudoclasses like :not(.some-class-name) which would previously get interpreted as 2 seperate selectors

main benefit from this change is that if you add :not(.gjs-selected) to all your states in selectorManager, the default one becomes a preview of your component as stateless rather than a life preview, which also fixes a issue where if your component is in dragMode absolute and some state offsets the position, making the dragging glitchy